### PR TITLE
Require II provenance identification for TS validation

### DIFF
--- a/src/main/java/org/sitenv/contentvalidator/model/CCDAAuthor.java
+++ b/src/main/java/org/sitenv/contentvalidator/model/CCDAAuthor.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import org.apache.log4j.Logger;
 import org.sitenv.contentvalidator.dto.ContentValidationResult;
 import org.sitenv.contentvalidator.dto.enums.ContentValidationResultLevel;
+import org.sitenv.contentvalidator.parsers.CCDAConstants;
 import org.sitenv.contentvalidator.parsers.ParserUtilities;
 
 public class CCDAAuthor {
@@ -173,13 +174,15 @@ public class CCDAAuthor {
 		ParserUtilities.compareEffectiveTimeValue(effTime, subAuthor.getEffTime(), results,
 				elementName);
 		
-		// Validate Times
-		ParserUtilities.validateTimeValueLengthDateTimeAndTimezoneDependingOnPrecision(subAuthor.getEffTime(), results,
-				elementName, 
-				(elName != null && !elName.isEmpty()) ? elName.replaceFirst(" , Comparing ", "") : elName,
-				-1, true);
+		// Validate Times (only applies to sub, not a comparison)
+		if (isAuthorOfTypeProvenance(subAuthor)) { // This check fixes SITE-3331
+			ParserUtilities.validateTimeValueLengthDateTimeAndTimezoneDependingOnPrecision(subAuthor.getEffTime(), results,
+					elementName, 
+					(elName != null && !elName.isEmpty()) ? elName.replaceFirst(" , Comparing ", "") : elName,
+					-1, true);
+		}
 		
-		// Compare RepOrg Name 
+		// Compare RepOrg Name
 		elementName = "Author Represented Organization Name for " + elName;					
 		if (submittedAuthorsWithLinkedReferenceData != null) {
 			ParserUtilities.compareProvenanceOrgName(orgName, subAuthor, results, elementName,
@@ -195,61 +198,67 @@ public class CCDAAuthor {
 		log.info(" Ref Model Auth Size = " + (refAuths != null ? refAuths.size() : 0));
 		log.info(" Sub Model Auth Size = " + (subAuths != null ? subAuths.size() : 0));
 
-		// TODO: Can remove this log after code is proven in production
-		// (already logged once which we can reference by CCDARefModel.logSubmittedAuthorsWithLinkedReferenceData 
-		// as opposed to every comparison encountered here
-		if (authorsWithLinkedReferenceData != null) {
-			for ( CCDAAuthor auth : authorsWithLinkedReferenceData) {
-				log.info(" authorsWithLinkedReferenceData: " );
-				auth.log();
-			}
-		}
+//		if (authorsWithLinkedReferenceData != null) {
+//			for (CCDAAuthor auth : authorsWithLinkedReferenceData) {
+//				log.info(" authorsWithLinkedReferenceData: " );
+//				auth.log();
+//			}
+//		}
     	
     	if (refAuths != null && refAuths.size() != 0) { // If no authors in scenario (ref) file, skip the comparison 			
 			for (CCDAAuthor curRefAuth : refAuths) {
 				
 				log.info("Checking Ref Author with Sub Authors ");
-				if(curRefAuth.getEffTime() != null && 
-						curRefAuth.getEffTime().getValuePresent()
-						&& !isProvenancePresent(curRefAuth.getEffTime(), curRefAuth.getOrgName(), subAuths)) {
-					
-					// Now that we know there is a failure inline, check the linked references. 
-					// The reason we wait is for performance, that way we only check the limited cases vs every case regardless beforehand
-					if (!isProvenancePresentInReferencesWithData(curRefAuth.getEffTime(), curRefAuth.getOrgName(),
-							subAuths, authorsWithLinkedReferenceData)) {
-					// Note: This is the only result that is actually reported.
-					// Many errors are generated in isProvenancePresent sub-routines but there's no way to connect them
-					// to a specific sub which actually had the issue (since match can be in any location) so instead the results
-					// generated externally are used as a reference for a boolean result which triggers this error 
-					// vs adding the unique errors themselves
-//					String message = "The scenario requires " + elName
-//							+ " (Time: Value) Provenance data which was not found in the submitted data. The scenario value is "
-//							+ auth.getEffTime().getValue().getValue()
-//							+ " and a submitted value must at a minimum match the 8-digit date portion of the data.";
-						final boolean isOrgNameNonNullAndPopulated = curRefAuth.getOrgName() != null
-								&& curRefAuth.getOrgName().getValue() != null
-								&& !curRefAuth.getOrgName().getValue().isEmpty();
-						String message = "The scenario requires " + elName
-								+ " Provenance data of time" + (isOrgNameNonNullAndPopulated ? " and/or representedOrganization/name" : "") 
-								+ " which was not found in the submitted data. "
-								+ "The scenario time value is " + curRefAuth.getEffTime().getValue().getValue()
-								+ " and a submitted time value should at a minimum match the 8-digit date portion of the data."
-								+ (isOrgNameNonNullAndPopulated ? " The scenario representedOrganization/name value is " + curRefAuth.getOrgName().getValue()
-								+ " and a submitted name should match. One or all of the prior issues exist and must be resolved." : "");																						
-							
-						ContentValidationResult rs = new ContentValidationResult(message,
-								ContentValidationResultLevel.ERROR, "/ClinicalDocument", "0");
-						results.add(rs);
+				// TODO: Consider if this check is appropriate, uncomment if so, and fix tests accordingly
+//				if (isAuthorOfTypeProvenance(curRefAuth)) {
+					// If there's an effectiveTime with a value in the ref, and the ref has provenance but the sub does not...
+					if (curRefAuth.getEffTime() != null && curRefAuth.getEffTime().getValuePresent()
+							&& !isProvenancePresent(curRefAuth.getEffTime(), curRefAuth.getOrgName(), subAuths)) {
+						
+						// Now that we know there is a failure inline, check the linked references. 
+						// The reason we wait is for performance, that way we only check the limited cases vs every case regardless beforehand
+						if (!isProvenancePresentInReferencesWithData(curRefAuth.getEffTime(), curRefAuth.getOrgName(),
+								subAuths, authorsWithLinkedReferenceData)) {
+							// Note: This is the only result that is actually reported.
+							// Many errors are generated in isProvenancePresent sub-routines but there's no way to connect them
+							// to a specific sub which actually had the issue (since match can be in any location) so instead the results
+							// generated externally are used as a reference for a boolean result which triggers this error 
+							// vs adding the unique errors themselves
+							final boolean isOrgNameNonNullAndPopulated = curRefAuth.getOrgName() != null
+									&& curRefAuth.getOrgName().getValue() != null
+									&& !curRefAuth.getOrgName().getValue().isEmpty();
+							String message = "The scenario requires " + elName
+									+ " Provenance data of time" + (isOrgNameNonNullAndPopulated ? " and/or representedOrganization/name" : "") 
+									+ " which was not found in the submitted data. "
+									+ "The scenario time value is " + curRefAuth.getEffTime().getValue().getValue()
+									+ " and a submitted time value should at a minimum match the 8-digit date portion of the data."
+									+ (isOrgNameNonNullAndPopulated ? " The scenario representedOrganization/name value is " + curRefAuth.getOrgName().getValue()
+									+ " and a submitted name should match. One or all of the prior issues exist and must be resolved." : "");																						
+								
+							ContentValidationResult rs = new ContentValidationResult(message,
+									ContentValidationResultLevel.ERROR, "/ClinicalDocument", "0");
+							results.add(rs);
+						} else {
+							log.info(
+									" Found Provenance data in submitted authorsWithLinkedReferenceData, nothing else to do ..");
+						}
+						
+						
 					} else {
-						log.info(
-								" Found Provenance data in submitted authorsWithLinkedReferenceData, nothing else to do ..");
+						log.info(" Found Provenance data, nothing else to do ..");
 					}
-					
-				} else {
-					log.info(" Found Provenance data, nothing else to do ..");
-				}
+//				} else {
+//					log.info(" Since the author " 
+//							+ ((curRefAuth.getTemplateIds() != null
+//							&& curRefAuth.getTemplateIds().size() > 0
+//							&& curRefAuth.getTemplateIds().get(0).getRootValue() != null)
+//									? curRefAuth.getTemplateIds().get(0).getRootValue()
+//									: "null or empty II")
+//									+ " is not a provenance II, there is no reason to compare it with the submitted file"
+//									+ "/check for provenance within it");
+//				}
 			}
-			
+						
 			// Validate time value in sub author time value instances specifically (not a comparison)
 			// Results are added as individual errors
 			if (subAuths != null && subAuths.size() > 0) {
@@ -259,13 +268,19 @@ public class CCDAAuthor {
 				int subAuthIndex = -1;
 				for (CCDAAuthor subAuth : subAuths) {
 					subAuthIndex++;
-					if (subAuth.getEffTime() != null) {
-						log.info("validating subauth at index " + subAuthIndex);
-						ParserUtilities.validateTimeValueLengthDateTimeAndTimezoneDependingOnPrecision(
-								subAuth.getEffTime(), results, localElName, elName, subAuthIndex, isSub);
-					} else {
-						log.info("subAuth at index " + subAuthIndex + " is null" );
-					}
+					// TODO: Consider adding check and updating tests to use provenance or otherwise if appropriate
+					// Note: Check causes Site3241Test(s) to fail due to that test (mistakenly?) using author participation II vs provenance
+//					if (isAuthorOfTypeProvenance(subAuth)) {
+						if (subAuth.getEffTime() != null) {
+							log.info("validating subauth at index " + subAuthIndex);
+							ParserUtilities.validateTimeValueLengthDateTimeAndTimezoneDependingOnPrecision(
+									subAuth.getEffTime(), results, localElName, elName, subAuthIndex, isSub);
+						} else {
+							log.info("subAuth effTime at index " + subAuthIndex + " is null" );
+						}
+//					} else {
+//						log.info("subAuth at index " + subAuthIndex + " does not contain the provenance II");
+//					}
 				}
 			} else {
 				log.info("subAuths is null or empty");
@@ -287,6 +302,16 @@ public class CCDAAuthor {
     	}		
 	}
     
+    public static boolean isAuthorOfTypeProvenance(CCDAAuthor author) {
+		if (author.templateIds != null) {
+			return author.templateIds.stream()
+				.anyMatch(templateId -> 
+					(templateId.getRootValue() != null && templateId.getRootValue().equals(CCDAConstants.PROVENANCE_TEMPLATE_ID_ROOT))
+				 && (templateId.getRootValue() != null && templateId.getExtValue().equals(CCDAConstants.PROVENANCE_TEMPLATE_ID_EXT)));
+    	}
+    	return false;
+    }
+    
     public static boolean isProvenancePresent(CCDAEffTime effTime, CCDADataElement refOrgName, ArrayList<CCDAAuthor> subAuths) {
     	log.info("enter isProvenancePresent(...)");
     	
@@ -298,17 +323,19 @@ public class CCDAAuthor {
     		log.info("subAuths is null, skipping: " + elName);
     	} else {
 	    	for(CCDAAuthor curSubAuth : subAuths) {
-	    		ParserUtilities.compareEffectiveTimeValue(effTime, curSubAuth.getEffTime(), contentValidationResults, elName);	    		
-	    		ParserUtilities.compareDataElementText(refOrgName, curSubAuth.getOrgName(), contentValidationResults, elName);
-	    		
-	    		if(contentValidationResults != null && contentValidationResults.size() == 0 ) {	    			
-	    			log.info(" Matched Provenance Data ");
-	    			isProvenanceMatched = true;
-	    			break;
-	    		}
-	    		else {
-	    			contentValidationResults.clear();
-	    		}
+	    		// TODO: Consider adding check if appropriate and updating tests as needed
+//	    		if (isAuthorOfTypeProvenance(curSubAuth)) {
+		    		ParserUtilities.compareEffectiveTimeValue(effTime, curSubAuth.getEffTime(), contentValidationResults, elName);	    		
+		    		ParserUtilities.compareDataElementText(refOrgName, curSubAuth.getOrgName(), contentValidationResults, elName);
+		    		
+		    		if (contentValidationResults != null && contentValidationResults.size() == 0 ) {	    			
+		    			log.info(" Matched Provenance Data ");
+		    			isProvenanceMatched = true;
+		    			break;
+		    		} else {
+		    			contentValidationResults.clear();
+		    		}
+//	    		}
 	    	}
 		}
     	

--- a/src/main/java/org/sitenv/contentvalidator/parsers/CCDAConstants.java
+++ b/src/main/java/org/sitenv/contentvalidator/parsers/CCDAConstants.java
@@ -184,6 +184,9 @@ public class CCDAConstants {
 	public static final String RN_CODE = "57133-1";
 	public static final String CP_TEMPLATE = "2.16.840.1.113883.10.20.22.1.15";
 	public static final String CP_CODE = "52521-2";
+
+	public static final String PROVENANCE_TEMPLATE_ID_ROOT = "2.16.840.1.113883.10.20.22.5.6";
+	public static final String PROVENANCE_TEMPLATE_ID_EXT = "2019-10-01";
 	
 	
 	private CCDAConstants()

--- a/src/main/java/org/sitenv/contentvalidator/parsers/ParserUtilities.java
+++ b/src/main/java/org/sitenv/contentvalidator/parsers/ParserUtilities.java
@@ -193,8 +193,7 @@ public class ParserUtilities {
 			ArrayList<ContentValidationResult> results, String elementName) {
 
 		// handle nulls.
-		if((refTime != null) && (submittedTime != null) ) {
-		
+		if ((refTime != null) && (submittedTime != null) ) {
 			log.info(" Effective Times are not null in both Ref and Submitted models, so compare value attributes for them. ");
 			refTime.compareValueElement(submittedTime, results, elementName);
 		
@@ -205,7 +204,7 @@ public class ParserUtilities {
 					ContentValidationResultLevel.ERROR, "/ClinicalDocument", "0");
 			results.add(rs);
 		}
-		else if((refTime != null && refTime.hasValidData()) && (submittedTime == null)){
+		else if ((refTime != null && refTime.hasValidData()) && (submittedTime == null)){
 			ContentValidationResult rs = new ContentValidationResult("The scenario requires " + elementName
 					+ " data, but submitted file does not contain " + elementName + " data",
 					ContentValidationResultLevel.ERROR, "/ClinicalDocument", "0");

--- a/src/test/java/ContentValidatorCuresTest.java
+++ b/src/test/java/ContentValidatorCuresTest.java
@@ -131,64 +131,76 @@ public class ContentValidatorCuresTest extends ContentValidatorTester {
 	private static final int SUB_REBECCA621_ONE_NOTE_ACT_INLINE_AUTH_MISMATCHED_NAME_3300 = 50;
 	private static final int SUB_HAS_NOTES_SEC_NOTE_ACT_AUTHOR_TIME_TIMEZONE_0400_SWITCH_E2_AND_E3_FOR_SITE_3263 = 51;
 	private static final int SUB_HAS_NOTES_SEC_NOTE_ACT_AUTHOR_TIME_TIMEZONE_0400_SWITCH_E2_AND_E1_FOR_SITE_3263 = 52;
+	private static final int SUB_VALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331 = 53;
+	private static final int SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331 = 54;
+	private static final int SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331 = 55;
+	private static final int SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331 = 56;
+	private static final int SUB_VALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331 = 57;
+	private static final int SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331 = 58;
 
 	private static URI[] SUBMITTED_CCDA = new URI[0];
 	static {
 		try {
 			SUBMITTED_CCDA = new URI[] {
-					ContentValidatorCuresTest.class.getResource(S+"RemoveAuthorInHeader_170.315_b1_toc_amb_ccd_r21_sample1_v13.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"C-CDA_R2-1_CCD_EF.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(R+"170.315_b1_toc_amb_sample3.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(PS+"170.315_b1_toc_amb_sample1_Submitted_T1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddNoteActivityWithAuthorToProcedures_b1_toc_amb_s1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddAuthorToProceduresProcedureActivityProcedure_b1_toc_amb_s1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddAuthorToResultsResultOrganizer_e1_vdt_amb_s1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddResultOrganizerWithoutAuthorToResults_e1_vdt_amb_s1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"HasNullFlavorOnResultOrganizerCode.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"DoesNotHaveNullFlavorOnResultOrganizerCode.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"DoesNotHaveNullFlavorOnResultOrganizerObservationCodes.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SocialHistoryWithoutBirthSexObsTemplateSite3094.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SocialHistoryWithBirthSexObsTemplateSite3094.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryFormerSmoker_b1_toc_amb_s3_Site3220.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryFormerSmoker_b1_inp_amb_s3_Site3220.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryUnknownSmoker_b1_toc_amb_s3_Site3220.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryUnknownSmoker_b1_inp_amb_s3_Site3220.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryFormerAndUnknownSmoker_b1_toc_amb_s3_Site3220.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_10AuthorsTotal_rebecca_Site3232.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_2AuthorsTotal_rebecca_Site3232.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_4AuthorsTotal_rebecca_Site3232.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_0AuthorsTotal_rebecca_Site3232.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"Add2AuthorsToProbSecConcObs_b1TocAmbCcdR21Sample1V13_Site3235.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"Has2AuthorsInHeader_b1TocAmbS1_Site3235.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(R+"170.315_b1_toc_amb_sample1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(R+"ModRef_AddNotesActivityEncounterEntry_b1TocAmbS1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(R+"ModRef_AddNotesActivityProcActProcEntryRel_b1TocAmbS1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"hasDateAndTimeForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"hasDateOnlyForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"hasDateOnlyInverseForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(R+"ModRef_AccurateDateAndTimeForAuthor_DocLvl_VitalSection_g9AAInpS1.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"hasMixedDateAndTimeForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3252_b1TocAmbS3.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"VitalSignsSecVSObsTime_happy413_repro_Site3261.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"VitalSignsSecVSObsTime_happy413_repro_match_name_Site3261.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"MedicationSecMedActProvTimeMismatched_happy416_Site3262.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"MedicationSecMedActProvTimeFixToMatch_happy416_Site3262.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_PROB_SEC_PROB_CONC_PROB_OBS_REPRO_HAPPYBLD420V2_MISSING_NAME_SITE_3265.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_PROB_SEC_PROB_CONC_PROB_OBS_REPRO_HAPPYBLD420V2_ADD_MATCHING_NAME_SITE_3265.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_CARE_TEAM_SEC_PERF_SITE_3259.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_CARE_TEAM_SEC_PERF_AND_PART_SITE_3259.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_SITE_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_MATCHED_TIME_SITE_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_MATCHED_TIME_BUT_MISSING_LINKED_REFERENCES_IN_DOCUMENT_SITE_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_VALID_LINK_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_VALID_INLINE_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_BAD_LINK_BAD_EXT_AND_ROOT_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_EMPTY_ASSIGNED_AUTHOR_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_VALID_LINK_BAD_NAME_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_NO_LINKED_REF_IN_DOC_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_INLINE_AUTH_MISMATCHED_NAME_3300.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3263_switchE2AndE3.xml").toURI(),
-					ContentValidatorCuresTest.class.getResource(S+"SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3263_switchE2AndE1.xml").toURI()
+					ContentValidatorCuresTest.class.getResource(S+"RemoveAuthorInHeader_170.315_b1_toc_amb_ccd_r21_sample1_v13.xml").toURI(), // 0
+					ContentValidatorCuresTest.class.getResource(S+"C-CDA_R2-1_CCD_EF.xml").toURI(), // 1
+					ContentValidatorCuresTest.class.getResource(R+"170.315_b1_toc_amb_sample3.xml").toURI(), // 2
+					ContentValidatorCuresTest.class.getResource(PS+"170.315_b1_toc_amb_sample1_Submitted_T1.xml").toURI(), // 3
+					ContentValidatorCuresTest.class.getResource(S+"AddNoteActivityWithAuthorToProcedures_b1_toc_amb_s1.xml").toURI(), // 4
+					ContentValidatorCuresTest.class.getResource(S+"AddAuthorToProceduresProcedureActivityProcedure_b1_toc_amb_s1.xml").toURI(), // 5
+					ContentValidatorCuresTest.class.getResource(S+"AddAuthorToResultsResultOrganizer_e1_vdt_amb_s1.xml").toURI(), // 6
+					ContentValidatorCuresTest.class.getResource(S+"AddResultOrganizerWithoutAuthorToResults_e1_vdt_amb_s1.xml").toURI(), // 7
+					ContentValidatorCuresTest.class.getResource(S+"HasNullFlavorOnResultOrganizerCode.xml").toURI(), // 8
+					ContentValidatorCuresTest.class.getResource(S+"DoesNotHaveNullFlavorOnResultOrganizerCode.xml").toURI(), // 9
+					ContentValidatorCuresTest.class.getResource(S+"DoesNotHaveNullFlavorOnResultOrganizerObservationCodes.xml").toURI(), // 10
+					ContentValidatorCuresTest.class.getResource(S+"SocialHistoryWithoutBirthSexObsTemplateSite3094.xml").toURI(), // 11
+					ContentValidatorCuresTest.class.getResource(S+"SocialHistoryWithBirthSexObsTemplateSite3094.xml").toURI(), // 12
+					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryFormerSmoker_b1_toc_amb_s3_Site3220.xml").toURI(), // 13
+					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryFormerSmoker_b1_inp_amb_s3_Site3220.xml").toURI(), // 14
+					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryUnknownSmoker_b1_toc_amb_s3_Site3220.xml").toURI(), // 15
+					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryUnknownSmoker_b1_inp_amb_s3_Site3220.xml").toURI(), // 16
+					ContentValidatorCuresTest.class.getResource(S+"AddSmokingStatusEntryFormerAndUnknownSmoker_b1_toc_amb_s3_Site3220.xml").toURI(), // 17
+					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_10AuthorsTotal_rebecca_Site3232.xml").toURI(), // 18
+					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_2AuthorsTotal_rebecca_Site3232.xml").toURI(), // 19
+					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_4AuthorsTotal_rebecca_Site3232.xml").toURI(), // 20
+					ContentValidatorCuresTest.class.getResource(S+"vitalSignsSectionWith5Organizers10Observations_0AuthorsTotal_rebecca_Site3232.xml").toURI(), // 21
+					ContentValidatorCuresTest.class.getResource(S+"Add2AuthorsToProbSecConcObs_b1TocAmbCcdR21Sample1V13_Site3235.xml").toURI(), // 22
+					ContentValidatorCuresTest.class.getResource(S+"Has2AuthorsInHeader_b1TocAmbS1_Site3235.xml").toURI(), // 23
+					ContentValidatorCuresTest.class.getResource(R+"170.315_b1_toc_amb_sample1.xml").toURI(), // 24
+					ContentValidatorCuresTest.class.getResource(R+"ModRef_AddNotesActivityEncounterEntry_b1TocAmbS1.xml").toURI(), // 25
+					ContentValidatorCuresTest.class.getResource(R+"ModRef_AddNotesActivityProcActProcEntryRel_b1TocAmbS1.xml").toURI(), // 26
+					ContentValidatorCuresTest.class.getResource(S+"hasDateAndTimeForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(), // 27
+					ContentValidatorCuresTest.class.getResource(S+"hasDateOnlyForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(), // 28
+					ContentValidatorCuresTest.class.getResource(S+"hasDateOnlyInverseForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(), // 29
+					ContentValidatorCuresTest.class.getResource(R+"ModRef_AccurateDateAndTimeForAuthor_DocLvl_VitalSection_g9AAInpS1.xml").toURI(), // 30
+					ContentValidatorCuresTest.class.getResource(S+"hasMixedDateAndTimeForAuthorTimeInDocLevAndVitalSignsSite3241.xml").toURI(), // 31
+					ContentValidatorCuresTest.class.getResource(S+"SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3252_b1TocAmbS3.xml").toURI(), // 32
+					ContentValidatorCuresTest.class.getResource(S+"VitalSignsSecVSObsTime_happy413_repro_Site3261.xml").toURI(), // 33
+					ContentValidatorCuresTest.class.getResource(S+"VitalSignsSecVSObsTime_happy413_repro_match_name_Site3261.xml").toURI(), // 34
+					ContentValidatorCuresTest.class.getResource(S+"MedicationSecMedActProvTimeMismatched_happy416_Site3262.xml").toURI(), // 35
+					ContentValidatorCuresTest.class.getResource(S+"MedicationSecMedActProvTimeFixToMatch_happy416_Site3262.xml").toURI(), // 36
+					ContentValidatorCuresTest.class.getResource(S+"SUB_PROB_SEC_PROB_CONC_PROB_OBS_REPRO_HAPPYBLD420V2_MISSING_NAME_SITE_3265.xml").toURI(), // 37
+					ContentValidatorCuresTest.class.getResource(S+"SUB_PROB_SEC_PROB_CONC_PROB_OBS_REPRO_HAPPYBLD420V2_ADD_MATCHING_NAME_SITE_3265.xml").toURI(), // 38
+					ContentValidatorCuresTest.class.getResource(S+"SUB_CARE_TEAM_SEC_PERF_SITE_3259.xml").toURI(), // 39
+					ContentValidatorCuresTest.class.getResource(S+"SUB_CARE_TEAM_SEC_PERF_AND_PART_SITE_3259.xml").toURI(), // 40
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_SITE_3300.xml").toURI(), // 41
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_MATCHED_TIME_SITE_3300.xml").toURI(), // 42
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_MATCHED_TIME_BUT_MISSING_LINKED_REFERENCES_IN_DOCUMENT_SITE_3300.xml").toURI(), // 43
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_VALID_LINK_3300.xml").toURI(), // 44
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_VALID_INLINE_3300.xml").toURI(), // 45
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_BAD_LINK_BAD_EXT_AND_ROOT_3300.xml").toURI(), // 46
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_EMPTY_ASSIGNED_AUTHOR_3300.xml").toURI(), // 47
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_VALID_LINK_BAD_NAME_3300.xml").toURI(), // 48
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_NO_LINKED_REF_IN_DOC_3300.xml").toURI(), // 49
+					ContentValidatorCuresTest.class.getResource(S+"SUB_REBECCA621_ONE_NOTE_ACT_INLINE_AUTH_MISMATCHED_NAME_3300.xml").toURI(), // 50
+					ContentValidatorCuresTest.class.getResource(S+"SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3263_switchE2AndE3.xml").toURI(), // 51
+					ContentValidatorCuresTest.class.getResource(S+"SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3263_switchE2AndE1.xml").toURI(), // 52
+					ContentValidatorCuresTest.class.getResource(S+"SUB_VALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml").toURI(), // 53
+					ContentValidatorCuresTest.class.getResource(S+"SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml").toURI(), // 54
+					ContentValidatorCuresTest.class.getResource(S+"SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331.xml").toURI(), // 55
+					ContentValidatorCuresTest.class.getResource(S+"SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml").toURI(), // 56
+					ContentValidatorCuresTest.class.getResource(S+"SUB_VALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml").toURI(), // 57
+					ContentValidatorCuresTest.class.getResource(S+"SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331.xml").toURI() // 58
 			};
 		} catch (URISyntaxException e) {
 			if(LOG_RESULTS_TO_CONSOLE) e.printStackTrace();
@@ -1365,7 +1377,7 @@ public class ContentValidatorCuresTest extends ContentValidatorTester {
 		String message = "The submitted Provenance (Time: Value) 201506221100 at Document Level is invalid. "
 				+ "Please ensure the time and time-zone starts with a 4 or 6-digit time, followed by a '+' or a '-', and finally, a 4-digit time-zone. "
 				+ "The invalid time and time-zone portion of the value is 1100."; 
-		expectError(message, results);		
+		expectError(message, results);
 		
 		// ---- Section level below ----		
 		
@@ -1768,21 +1780,25 @@ public class ContentValidatorCuresTest extends ContentValidatorTester {
 				+ "but submitted CCDA ( Time Value ) is : 149206221100-0500 which does not match"; 		
 		assertTrue("Results should have contained the following message but did not: " + message, 
 				resultsContainMessage(message, results, ContentValidationResultLevel.ERROR));
-		*/
+		*/		
 		
 		// T3
 		// Notes Section/Note Activity entry 3/author/time
 		//
+		// *Note: This is the only test which tests for the sub only, for an invalid TS (if provenance)
+		// As such, this test, and the sub, were updated to be provenance instead of author participation (as per SITE-3331)		
+		//
 		// ref | ModRef_ChangeNotesTimes_b1TocAmbS3.xml
+		// Note: The ref data is not relevant to how the error is produced in this case, but here it is regardless...
         // <author>
         // <templateId root="2.16.840.1.113883.10.20.22.4.119" />
 		//					<time value="198506221100-0500" />		
 		// sub | SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3252_b1TocAmbS3.xml
-        // <author>
-        // <templateId root="2.16.840.1.113883.10.20.22.4.119" />
-		//					<time value="198506221100-05AB" />
+		// <!-- Provenance = 5.6 -->
+        // <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+		// 					<time value="198506221100-05AB" />		
 		//  Comparison: 
-		//  ref time zone is correct, 4 digits, sub time-zone is incorrect, has letters. 
+		//  ref time zone is correct, 4 digits, sub time-zone is incorrect, has letters.
 		//  Although since this is validation, comparison is irrelevant, only looking at sub, and sub fails alone
 		//  Expected result: Fail (invalid format on time-zone - has 04AB, not 4 digits)
 		message = "The submitted Provenance (Time: Value) 198506221100-05AB at Note Activity Author Entry "
@@ -3021,6 +3037,331 @@ public class ContentValidatorCuresTest extends ContentValidatorTester {
 				+ "Author Represented Organization Name for Note Activity Author Entry for Notes Section "
 				+ "corresponding to the code 11506-3, but submitted file contains Provenance Org Name of: (Dan's Physicians Practice) "
 				+ "which does not match the inline author data.", results);
+	}
+	
+	@Test
+	public void cures_NoteActivity_ValidProvenanceTS_InvalidAuthorParticipationTS_Repro_Site3331Test() {
+		printHeader(new Object() {}.getClass().getEnclosingMethod().getName());
+				
+		// ETT GG, ContentVal: "Validator provenance timestamp errors when multiple author nodes present"
+		// https://groups.google.com/g/edge-test-tool/c/SHhXehxABZg/m/ZtdajeaQAgAJ
+		// https://oncprojectracking.healthit.gov/support/browse/SITE-3331
+		
+		ArrayList<ContentValidationResult> results = validateDocumentAndReturnResultsCures(
+				B1_TOC_AMB_VALIDATION_OBJECTIVE, REF_CURES_B1_TOC_AMB_SAMPLE1_ALICE_DEF_V2,
+				SUBMITTED_CCDA[SUB_VALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331],
+				SeverityLevel.ERROR);
+		printResults(results);
+				
+		// sub
+        /* 
+        Error 1 in Procedures/Note Activity:
+        
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+							<!-- Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<!-- relevant identifying code 28570-0 in error -->
+                                <translation code="28570-0" displayName="Procedure note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_Procedures_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+								<!-- -dbTest here is the location of the time which errors for provenance
+											 but it is actually the original Author Participation (see II, 4.119, NOT 5.6  -->                                
+                                <time value="20210125145611"/> <!-- this time is incorrectly reported as a 'provenance' error -->
+
+        */
+		//  Validation: 
+		//  Although the TS is invalid as per provenenace reqs (has no time-zone) for Author Participation, 
+		//  we do not expect an error for Author Participation time as it has looser regEx TS-only reqs, and, 
+		//  most importantly, it is not provenance. 
+		//  They are different templates with different IIs.
+		//  We are only enforcing TS validation for provenance within the content validator.
+		//  Non-provenance authors will be validated in the future by MDHT as per the schema regEx for TS.
+		//  Those regEx requirements are less strict than what we are applying for provenance.
+		//  There may be a duplication for provenance as well in MDHT.
+		expectNoError("The submitted Provenance (Time: Value) 20210125145611 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 28570-0 is invalid", results);
+		
+		/*
+		Error 2 in Progress Note/Note Activity
+		
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                        	<!--  Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11506-3" displayName="Progress note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_ProgressNoteNoteClinicalNotes_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210920"/>
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 invalid TS as per provenance reqs, but is not provenance, so should not be content validation error
+                                 -->
+                                <time value="20210920144244"/>		
+		 
+		*/
+		// Validation:
+		// The same bug is happening in Progress Note/Note Activity/Author Participation.
+		// Although it is invalid, it is not provenance and therefore should not produce the error within the content validator.
+		// Has no time-zone
+		expectNoError("The submitted Provenance (Time: Value) 20210920144244 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 11506-3 is invalid", results);		
+	}
+	
+	@Test
+	@Ignore // ignore until we have fixed the index bug as provenance is the 2nd index, not 1st, and cannot fail yet
+	public void cures_NoteActivity_InvalidProvenanceTS_ValidAuthorParticipationTS_Test() {
+		printHeader(new Object() {}.getClass().getEnclosingMethod().getName());				
+		
+		ArrayList<ContentValidationResult> results = validateDocumentAndReturnResultsCures(
+				B1_TOC_AMB_VALIDATION_OBJECTIVE, REF_CURES_B1_TOC_AMB_SAMPLE1_ALICE_DEF_V2,
+				SUBMITTED_CCDA[SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331],
+				SeverityLevel.ERROR);
+		printResults(results);
+				
+		// sub
+        /* 
+        Error 1 in Procedures/Note Activity:
+        
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+								<!-- this time should now show up as a valid provenance error as is provenance and has no time-zone -->
+                                <time value="20210125145611"/>
+
+        */
+		expectError("The submitted Provenance (Time: Value) 20210125145611 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 28570-0 is invalid", results);
+		
+		/*
+		Error 2 in Progress Note/Note Activity
+		
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+		 
+		*/
+		expectError("The submitted Provenance (Time: Value) 20210920144244 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 11506-3 is invalid", results);		
+	}
+	
+	@Test
+	public void cures_NoteActivity_InvalidProvenanceTS_ValidAuthorParticipationTS_SwapAuthorIndexes_Site3331Test() {
+		printHeader(new Object() {}.getClass().getEnclosingMethod().getName());
+				
+		// ETT GG, ContentVal: "Validator provenance timestamp errors when multiple author nodes present"
+		// https://groups.google.com/g/edge-test-tool/c/SHhXehxABZg/m/ZtdajeaQAgAJ
+		// https://oncprojectracking.healthit.gov/support/browse/SITE-3331
+		
+		ArrayList<ContentValidationResult> results = validateDocumentAndReturnResultsCures(
+				B1_TOC_AMB_VALIDATION_OBJECTIVE, REF_CURES_B1_TOC_AMB_SAMPLE1_ALICE_DEF_V2,
+				SUBMITTED_CCDA[SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331],
+				SeverityLevel.ERROR);
+		printResults(results);
+		
+		// This test is the same as cures_NoteActivity_InvalidProvenanceTS_ValidAuthorParticipationTS_Site3331Test except that
+		// the indexes of the authors are swapped. The reason for this is that there is a bug where only the 1st author index will fail.
+		// Until we resolve that bug, we need to swap the provenance with the error to the first occurring author, so that it can fail for it's
+		// TS, and prove proper identification.
+		// After the index bug is fixed, this will remain as a regression test.
+				
+		// sub
+        /* 
+        Error 1 in Procedures/Note Activity:
+		Same as cures_NoteActivity_InvalidProvenanceTS_ValidAuthorParticipationTS_Site3331Test but now provenance is 1st author vs 2nd
+
+        */
+		expectError("The submitted Provenance (Time: Value) 20210125145611 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 28570-0 is invalid", results);
+		
+		/*
+		Error 2 in Progress Note/Note Activity
+		Same as cures_NoteActivity_InvalidProvenanceTS_ValidAuthorParticipationTS_Site3331Test but now provenance is 1st author vs 2nd
+		 
+		*/
+		expectError("The submitted Provenance (Time: Value) 20210920144244 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 11506-3 is invalid", results);		
+	}
+	
+	@Test
+	@Ignore // ignore until we have fixed the index bug as provenance is the 2nd index, not 1st, and cannot fail yet
+	public void cures_NoteActivity_InvalidProvenanceTS_InvalidAuthorParticipationTS_Test() {
+		printHeader(new Object() {}.getClass().getEnclosingMethod().getName());				
+		
+		ArrayList<ContentValidationResult> results = validateDocumentAndReturnResultsCures(
+				B1_TOC_AMB_VALIDATION_OBJECTIVE, REF_CURES_B1_TOC_AMB_SAMPLE1_ALICE_DEF_V2,
+				SUBMITTED_CCDA[SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331],
+				SeverityLevel.ERROR);
+		printResults(results);
+		
+		// sub
+		/*
+		Non-Error 1 in Procedures/Note Activity:
+ 		AuthorParticipation TS being invalid is irrelevant/not supposed to be enforced so not fired
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20660125145611"/> 					 
+		 */		
+		expectNoError("The submitted Provenance (Time: Value) 20660125145611 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 28570-0 is invalid", results);
+				
+		// sub
+        /* 
+        Error 1 in Procedures/Note Activity:
+        
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- this time should now show up as a valid provenance error as is provenance and has no time-zone -->
+                                <time value="20210125145611"/>
+
+        */
+		expectError("The submitted Provenance (Time: Value) 20210125145611 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 28570-0 is invalid", results);
+		
+		
+		/*
+		Non-Error 2 in Progress Note/Note Activity
+		
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 INvalid TS as per provenance reqs, but is not provenance, so irrelevant, no error expected
+                                 -->
+                                <time value="20660920144244"/>
+		 
+		*/
+		expectNoError("The submitted Provenance (Time: Value) 20660920144244 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 11506-3 is invalid", results);		
+		
+		/*
+		Error 2 in Progress Note/Note Activity
+		
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+		 
+		*/
+		expectError("The submitted Provenance (Time: Value) 20210920144244 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 11506-3 is invalid", results);
+	}
+	
+	@Test
+	public void cures_NoteActivity_ValidProvenanceTS_ValidAuthorParticipationTS_EpectPass_Site3331Test() {
+		printHeader(new Object() {}.getClass().getEnclosingMethod().getName());
+				
+		// ETT GG, ContentVal: "Validator provenance timestamp errors when multiple author nodes present"
+		// https://groups.google.com/g/edge-test-tool/c/SHhXehxABZg/m/ZtdajeaQAgAJ
+		// https://oncprojectracking.healthit.gov/support/browse/SITE-3331
+		
+		ArrayList<ContentValidationResult> results = validateDocumentAndReturnResultsCures(
+				B1_TOC_AMB_VALIDATION_OBJECTIVE, REF_CURES_B1_TOC_AMB_SAMPLE1_ALICE_DEF_V2,
+				SUBMITTED_CCDA[SUB_VALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331],
+				SeverityLevel.ERROR);
+		printResults(results);
+				
+		// All times are valid, no provenance issues expected at all
+		// All 4 instances should pass. 
+		// The 2 Author Participation authors would never fail either way. 
+		// The 2 Provenance would if fail invalid, but are valid.
+		// Search dbTest to find the instances
+		expectNoError("The submitted Provenance (Time: Value) ", results);
+	}
+	
+	@Test
+	public void cures_NoteActivity_InvalidProvenanceTS_InvalidAuthorParticipationTS_SwapAuthorIndexes_Test() {
+		printHeader(new Object() {}.getClass().getEnclosingMethod().getName());				
+		
+		ArrayList<ContentValidationResult> results = validateDocumentAndReturnResultsCures(
+				B1_TOC_AMB_VALIDATION_OBJECTIVE, REF_CURES_B1_TOC_AMB_SAMPLE1_ALICE_DEF_V2,
+				SUBMITTED_CCDA[SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331],
+				SeverityLevel.ERROR);
+		printResults(results);
+		
+		// sub
+        /* 
+        Error 1 in Procedures/Note Activity:
+        
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- this time should now show up as a valid provenance error as is provenance and has no time-zone -->
+                                <time value="20210125145611"/>
+
+        */
+		expectError("The submitted Provenance (Time: Value) 20210125145611 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 28570-0 is invalid", results);		
+		
+		// sub
+		/*
+		Non-Error 1 in Procedures/Note Activity:
+ 		AuthorParticipation TS being invalid is irrelevant/not supposed to be enforced so not fired
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20660125145611"/> 					 
+		 */		
+		expectNoError("The submitted Provenance (Time: Value) 20660125145611 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 28570-0 is invalid", results);
+
+		/*
+		Error 2 in Progress Note/Note Activity
+		
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+		 
+		*/
+		expectError("The submitted Provenance (Time: Value) 20210920144244 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 11506-3 is invalid", results);		
+		
+		/*
+		Non-Error 2 in Progress Note/Note Activity
+		
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 INvalid TS as per provenance reqs, but is not provenance, so irrelevant, no error expected
+                                 -->
+                                <time value="20660920144244"/>
+		 
+		*/
+		expectNoError("The submitted Provenance (Time: Value) 20660920144244 at Note Activity Author Entry for Notes Section "
+				+ "corresponding to the code 11506-3 is invalid", results);		
 	}	
 	
 }

--- a/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
+++ b/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
@@ -1,0 +1,10362 @@
+<?xml version="1.0"?><?xml-stylesheet type='text/xsl' href='http://www.nextgenshare.com/public/CDA_NGMU2.xsl'?>
+<ClinicalDocument xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc"
+    xmlns="urn:hl7-org:v3" xmlns:mif="urn:hl7-org:v3/mif"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US"/>
+    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+    <id root="1.3.6.1.4.1.21367.13.40.117" extension="f0b0de8a-dfd1-458b-99a5-523011eba40b"/>
+    <code code="34133-9" displayName="SUMMARIZATION OF EPISODE NOTE"
+        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+    <title>Continuity of Care Document (C-CDA R2.1)</title>
+    <effectiveTime value="20210920164540-0400"/>
+    <confidentialityCode code="N" displayName="Normal Sharing" codeSystem="2.16.840.1.113883.5.25"
+        codeSystemName="HL7 Confidentiality"/>
+    <languageCode code="en-US"/>
+    <recordTarget>
+        <patientRole>
+            <id extension="8658" root="1.100"/>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom use="MC" value="tel:+1-5557771234"/>
+            <telecom use="HP" value="tel:+1-5557231544"/>
+            <telecom value="mailto:sadavis@nextgen.com"/>
+            <patient>
+                <name use="L">
+                    <family>Newman</family>
+                    <given qualifier="CL">Alice</given>
+                    <given>Jones</given>
+                </name>
+                <name use="SRCH">
+                    <family>Newman</family>
+                    <given qualifier="BR">Alicia</given>
+                </name>
+                <administrativeGenderCode code="F" displayName="Female"
+                    codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
+                <birthTime value="19700501"/>
+                <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicitys"/>
+                <sdtc:raceCode code="2108-9" displayName="European"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+                <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicitys"/>
+                <languageCommunication>
+                    <templateId root="2.16.840.1.113883.3.88.11.32.2"/>
+                    <languageCode code="en"/>
+                    <preferenceInd value="true"/>
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id root="1.174" extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+        </assignedAuthor>
+    </author>
+    <author>
+        <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id nullFlavor="UNK"/>
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom value="5555551002"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom value="5555551002"/>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <informant>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Admin</family>
+                    <given>NEXTGEN</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </informant>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <legalAuthenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom use="WP" nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </legalAuthenticator>
+    <authenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </authenticator>
+    <participant typeCode="IND">
+        <time value="19400101"/>
+        <associatedEntity classCode="PRS">
+            <code code="GRPRN" displayName="grandparent" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="04" displayName="Grandparent"
+                    codeSystem="2.16.840.1.113883.3.109" codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Holler</family>
+                    <given>Rick</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <time value="19790101"/>
+        <associatedEntity classCode="PRS">
+            <code code="SPS" displayName="spouse" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="01" displayName="Spouse" codeSystem="2.16.840.1.113883.3.109"
+                    codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Newman</family>
+                    <given>Matthew</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <associatedEntity classCode="CAREGIVER">
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+            </addr>
+            <telecom use="HP" value="tel:+1-5555551002"/>
+            <associatedPerson>
+                <name>
+                    <family>Allison</family>
+                    <given>Kristin</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <functionCode code="PCP" codeSystem="2.16.840.1.113883.5.88"/>
+        <associatedEntity classCode="CAREGIVER">
+            <associatedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <documentationOf typeCode="DOC">
+        <serviceEvent classCode="PCPR">
+            <effectiveTime>
+                <low value="201506221000"/>
+                <high value="202109201436"/>
+            </effectiveTime>
+            <performer typeCode="PRF">
+                <time>
+                    <low value="202109201645"/>
+                    <high value="202109201645"/>
+                </time>
+                <assignedEntity>
+                    <id root="1.174" extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"/>
+                    <addr>
+                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                        <city>Tripler Army Medical Center</city>
+                        <state>HI</state>
+                        <postalCode>96859-5000</postalCode>
+                        <country>US</country>
+                    </addr>
+                    <telecom nullFlavor="UNK"/>
+                    <assignedPerson>
+                        <name>
+                            <given>TerryThisIsAReallyLongFi</given>
+                            <family>HoitzThisIsAReallyLongLa</family>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </performer>
+        </serviceEvent>
+    </documentationOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Alerts"/>
+                    <code code="48765-2" displayName="Allergies and adverse reactions Document"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Allergies, Adverse Reactions, Alerts</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Substance</th>
+                                    <th>Reaction</th>
+                                    <th>Status</th>
+                                    <th>Criticality</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_0" xmlns="urn:hl7-org:v3"
+                                            >penicillin G </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_0_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_0_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_0" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_0" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_1" xmlns="urn:hl7-org:v3"
+                                            >ampicillin </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_1_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_1_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_1" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_1" xmlns="urn:hl7-org:v3"
+                                            >Low</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201810241352-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Canonica</family>
+                                                  <given>Gina</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="7980" displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_0"/>
+                                                  </originalText>
+                                                  <translation code="4977"
+                                                  displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>penicillin G</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_0_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_0_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_0_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101121613-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="733" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_1"/>
+                                                  </originalText>
+                                                  <translation code="2692" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>ampicillin</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_1_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_1_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_1_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="CRITL" displayName="Low"
+                                                codeSystem="2.16.840.1.113883.5.1063"
+                                                codeSystemName="HL7SeverityObservation"
+                                                xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Medications"/>
+                    <code code="10160-0" displayName="History of Medication use Narrative"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_0" xmlns="urn:hl7-org:v3"
+                                            >Aranesp 500 mcg/mL (in polysorbate) injection
+                                            syringe</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_0" xmlns="urn:hl7-org:v3">inject
+                                            1 milliliter by subcutaneous route every week</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_0" xmlns="urn:hl7-org:v3">2.25
+                                            MCG/KG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_1" xmlns="urn:hl7-org:v3"
+                                            >clindamycin 300 mg capsule</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_1" xmlns="urn:hl7-org:v3">take 1
+                                            capsule by oral route 3 times every day if pain does not
+                                            subside as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_1" xmlns="urn:hl7-org:v3">300
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-01-2017 - Oct-30-2018</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_2" xmlns="urn:hl7-org:v3"
+                                            >Tylenol Extra Strength 500 mg tablet</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_2" xmlns="urn:hl7-org:v3">take 1
+                                            tablet by oral route every 4 hours as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_2" xmlns="urn:hl7-org:v3">500
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jul-01-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_2" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_3" xmlns="urn:hl7-org:v3"
+                                            >ceftriaxone 100 gram solution for injection</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_3" xmlns="urn:hl7-org:v3">inject
+                                            10 milligram by injection route 2 times every
+                                            day</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_3" xmlns="urn:hl7-org:v3">10
+                                            milligram</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jun-30-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="5418eadb-2b53-4aa6-9875-2f918456f0fa"/>
+                            <text>
+                                <reference value="#MedicationSig_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="1" unit="wk"/>
+                            </effectiveTime>
+                            <routeCode code="C38299" displayName="SUBCUTANEOUS"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="mL"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="731241"
+                                            displayName="1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe [Aranesp]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_0"/>
+                                            </originalText>
+                                            <translation code="55513003201"
+                                                displayName="darbepoetin alfa in polysorbat"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe
+                                            [Aranesp]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706142020-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="ddd500c2-4399-4a50-addd-aa2c26fa3fdf"/>
+                            <text>
+                                <reference value="#MedicationSig_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20170901"/>
+                                <high value="20181030"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="true" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="8" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{capsule}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="748748"
+                                            displayName="clindamycin 300 MG Oral Capsule [Cleocin]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_1"/>
+                                            </originalText>
+                                            <translation code="00527138301"
+                                                displayName="clindamycin HCl"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>clindamycin 300 MG Oral Capsule [Cleocin]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170901"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201810241401-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="6936cfb5-ad96-457e-8a90-1d71fd7e71f9"/>
+                            <text>
+                                <reference value="#MedicationSig_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150701"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="4" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{tablet}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="209459"
+                                            displayName="acetaminophen 500 MG Oral Tablet [Tylenol]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_2"/>
+                                            </originalText>
+                                            <translation code="00450044406"
+                                                displayName="acetaminophen"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>acetaminophen 500 MG Oral Tablet [Tylenol]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101141402-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="f6552a8d-5ae6-42ce-a4a8-e86bcba51a7d"/>
+                            <text>
+                                <reference value="#MedicationSig_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150630"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="12" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38291" displayName="PARENTERAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="10" unit="mg"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="309090"
+                                            displayName="ceftriaxone 100 MG/ML Injectable Solution"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_3"/>
+                                            </originalText>
+                                            <translation code="66288610001"
+                                                displayName="ceftriaxone sodium"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201554-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Problems"/>
+                    <code code="11450-4" displayName="PROBLEM LIST"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Problems</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Condition</th>
+                                    <th>Type</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Clinical Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Chronic rejection of renal
+                                            transplant</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Overweight</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - Jun-01-2007</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Problem resolved
+                                            (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="dc419944-c4a3-4343-9782-7c3468b5be90"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="386661006" displayName="Fever"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202102081114-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="770ff05e-9f26-4245-a4e6-48c88b7a8a6e"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="236578006"
+                                        displayName="Chronic rejection of renal transplant"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111005"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="59621000" displayName="Essential hypertension"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111005"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems2"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="83986005" displayName="Severe hypothyroidism"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101191712-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems3"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems4"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                                <high value="20070601"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="cb229847-35f2-4d70-bc2d-b3713e82763d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high value="20070601"/>
+                                    </effectiveTime>
+                                    <value code="238131007" displayName="Overweight"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201705081255-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems4"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="413322009"
+                                                displayName="Problem resolved (finding)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+					<!-- Procedures Section -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Procedures"/>
+                    <code code="47519-4" displayName="HISTORY OF PROCEDURES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Procedures</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure</th>
+                                    <th>Universal Device Identifier/Device Identifier</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_0" xmlns="urn:hl7-org:v3"
+                                            >Nebulizer Therapy</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_1" xmlns="urn:hl7-org:v3"
+                                            >Introduction of cardiac pacemaker system via
+                                            vein</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4 -
+                                                (01)00643169007222(17)160128(21)BLC200461H</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_3" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_Procedures_0" xmlns="urn:hl7-org:v3"
+                                            >Dr Albert Davis examined Ms Alice Newman and found that
+                                            the pacemaker is operating properly and the
+                                            breathlessness is due to high fever and
+                                            anxiety.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="aaff7f65-82dc-4039-85ac-5db62a9d983e"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_0"/>
+                                </originalText>
+                                <translation code="94640" displayName="Nebulizer Therapy"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101112008-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_1"/>
+                                </originalText>
+                                <translation code="33216"
+                                    displayName="Introduction of cardiac pacemaker system via vein"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                                <high value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.37"/>
+                                    <id root="1.3.160"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="GS1"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK"/>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="1.3.160"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="ff884e65-94e1-4e11-9438-74b67d03da41"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_2"/>
+                                </originalText>
+                                <translation code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                                <high value="20200304"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041448-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="07250fe9-b4ac-485f-b42d-3dff1df1ddd8"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_3"/>
+                                </originalText>
+                                <translation code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                                <high value="20200228"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281407-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+							<!-- Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<!-- relevant identifying code 28570-0 in error -->
+                                <translation code="28570-0" displayName="Procedure note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_Procedures_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+								<!-- -dbTest 1 - update to be INvalid (but not provenance anyway -->
+                                <time value="20660125145611"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- this time should now show up as a valid provenance error as is provenance and has no time-zone -->
+                                <time value="20210125145611"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Results"/>
+                    <code code="30954-2"
+                        displayName="Relevant diagnostic tests &amp;or laboratory data"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Results</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Test Name</th>
+                                    <th>Date and Time</th>
+                                    <th>Measure</th>
+                                    <th>Units</th>
+                                    <th>Reference Range</th>
+                                    <th>Abnormal Flag</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_0" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Urinanalysis macro (dipstick)
+                                            panel</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_0" xmlns="urn:hl7-org:v3"
+                                            >SPECIMEN: source: Urine specimen, Urine</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_0" xmlns="urn:hl7-org:v3"
+                                            >Color of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_0"
+                                            xmlns="urn:hl7-org:v3">YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_0" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_1" xmlns="urn:hl7-org:v3"
+                                            >Appearance of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_1"
+                                            xmlns="urn:hl7-org:v3">CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_1" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_2" xmlns="urn:hl7-org:v3"
+                                            >Specific gravity of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>1.015</content>
+                                    </td>
+                                    <td>
+                                        <content>1</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_2"
+                                            xmlns="urn:hl7-org:v3">1.005-1.030</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_2" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_3" xmlns="urn:hl7-org:v3"
+                                            >pH of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>5.0</content>
+                                    </td>
+                                    <td>
+                                        <content>pH</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_3"
+                                            xmlns="urn:hl7-org:v3">5.0-8.0</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_3" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_4" xmlns="urn:hl7-org:v3"
+                                            >Glucose [Mass/volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>50</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_4"
+                                            xmlns="urn:hl7-org:v3">Neg</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_4" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_5" xmlns="urn:hl7-org:v3"
+                                            >Ketones [Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_5"
+                                            xmlns="urn:hl7-org:v3">Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_5" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_6" xmlns="urn:hl7-org:v3"
+                                            >Protein[Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>100</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_6"
+                                            xmlns="urn:hl7-org:v3">negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_6" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_1" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Chest X-ray 2 views</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_1_0" xmlns="urn:hl7-org:v3"
+                                            >Chest X-ray 2 Views</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 21:54:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Abnormal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_1_0"
+                                            xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>A</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_1_0" xmlns="urn:hl7-org:v3">Lungs
+                                            are not clear, cannot rule out Anemia. Other tests are
+                                            required to determine the presence or absence of Anemia.
+                                        </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note Type</th>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Laboratory Report Narrative</content>
+                                    </td>
+                                    <td>
+                                        <content ID="clinNotes_Results_0" xmlns="urn:hl7-org:v3">Ms
+                                            Alice Newman was tested for the Urinanalysis macro panel
+                                            and the results have been found to be normal.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="f05926e4-90b4-4d39-b7db-46c5ae2c28bf"/>
+                            <code code="24357-6" displayName="Urinanalysis macro (dipstick) panel"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_0"/>
+                                </originalText>
+                                <translation code="81002"
+                                    displayName="Urinalysis, non-automated, w/scope"
+                                    codeSystemName="L"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000-0400"/>
+                                <high value="20150622110000-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622110000"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706301717-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Interface</family>
+                                            <given>Rosetta</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5778-6" displayName="Color of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">YELLOW</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>YELLOW</text>
+                                            <value xsi:type="ST">YELLOW</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5767-9" displayName="Appearance of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">CLEAR</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>CLEAR</text>
+                                            <value xsi:type="ST">CLEAR</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5811-5"
+                                        displayName="Specific gravity of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="1.015" unit="1"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>1.005-1.030</text>
+                                            <value xsi:type="ST">1.005-1.030</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5803-2" displayName="pH of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="5.0" unit="[pH]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>5.0-8.0</text>
+                                            <value xsi:type="ST">5.0-8.0</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5792-7"
+                                        displayName="Glucose [Mass/volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="50" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Neg</text>
+                                            <value xsi:type="ST">Neg</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5797-6"
+                                        displayName="Ketones [Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_5"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">Negative</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Negative</text>
+                                            <value xsi:type="ST">Negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5804-0"
+                                        displayName="Protein[Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_6"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="100" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>negative</text>
+                                            <value xsi:type="ST">negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="5f09fddb-1a80-4a65-8d24-8a2a08637f09"/>
+                            <code code="36643-5" displayName="Chest X-ray 2 views"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_1"/>
+                                </originalText>
+                                <translation code="71010" displayName="Chest X-ray"
+                                    codeSystemName="R"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622115900-0400"/>
+                                <high value="20150622115900-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622115900"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706281613-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="36643-5" displayName="Chest X-ray 2 Views"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_1_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622215400-0400"/>
+                                    <value xsi:type="ST">Abnormal</value>
+                                    <interpretationCode code="A" displayName="Abnormal"
+                                        codeSystem="2.16.840.1.113883.5.83"
+                                        codeSystemName="HL7 Observation Interpretation"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622115900"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706281613-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>User</family>
+                                                  <given>Adam</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                            <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ResultComment_1_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                        </act>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#clinNotes_Results_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20210125145624"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="AdvanceDirectives"/>
+                    <code code="42348-3" displayName="ADVANCE DIRECTIVES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Advance Directives</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Directive</th>
+                                    <th>Yes / No</th>
+                                    <th>Effective Date</th>
+                                    <th>File Name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownAdvanceDirective" xmlns="urn:hl7-org:v3"
+                                            >No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Encounters"/>
+                    <code code="46240-8" displayName="HISTORY OF ENCOUNTERS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Encounters</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Description</th>
+                                    <th>Practice</th>
+                                    <th>Location</th>
+                                    <th>Reason(s) For Visit</th>
+                                    <th>Diagnoses</th>
+                                    <th>Date</th>
+                                    <th>Provider</th>
+                                    <th>Providers Copied on Encounter</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                    <td>
+                                        <content>HoitzThisIsAReallyLongLa TerryThisIsAReallyLongFi.
+                                            1 Jarrett White Rd, Tripler Army Medical Center, HI,
+                                            968595000, US. tel:+1-8084331212</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_1" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>
+                                                <content>sore throat (chief complaint)</content>
+                                            </item>
+                                            <item>
+                                                <content>Sore throat (chief complaint)</content>
+                                            </item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Acute tonsillitis due to other specified
+                                                organisms</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension (chief complaint)</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Hypertension</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Fever - Finding</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="9d7d931c-948f-4a59-a532-d9b96c868129"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_0"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202109201436"/>
+                                <high value="202109201436"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                                        <city>Tripler Army Medical Center</city>
+                                        <state>HI</state>
+                                        <postalCode>96859-5000</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-8084331212"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>HoitzThisIsAReallyLongLa</family>
+                                            <given>TerryThisIsAReallyLongFi</given>
+                                            <given>TerrysMiddleName-35-</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id nullFlavor="UNK"/>
+                                            <code nullFlavor="UNK">
+                                                <translation nullFlavor="UNK"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"/>
+                            <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_1"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202003041348"/>
+                                <high value="202003041348"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200304"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_1"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="285533fa-4983-4e30-b718-c2942646ea36"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="J03.80"
+                                                displayName="Acute tonsillitis due to other specified organisms"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time nullFlavor="UNK"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202003041440-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="26db8415-1153-455c-a328-da1aeb35e30f"/>
+                            <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_2"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202002281351"/>
+                                <high value="202002281351"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200228"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_2"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="5ad6f921-233e-4d8c-927d-ecfd26bfbaf9"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20200228"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="I10" displayName="Hypertension"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20200228"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202002281406-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_3"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="201506221000"/>
+                                <high value="201506221000"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                            <code code="~" displayName="~"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation nullFlavor="NA"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20150622"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="R50.9" displayName="Fever - Finding"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20150622"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202103261221-0400"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom value="5555551002"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FamilyHistory"/>
+                    <code code="10157-6" displayName="HISTORY OF FAMILY MEMBER DISEASES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Family History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Family Member</th>
+                                    <th>Type</th>
+                                    <th>Diagnosis</th>
+                                    <th>Age At Onset</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_0"
+                                            xmlns="urn:hl7-org:v3">Alive and well</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_1"
+                                            xmlns="urn:hl7-org:v3">Family history of
+                                            asthma</content>
+                                    </td>
+                                    <td>
+                                        <content>16</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"
+                                extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <statusCode code="completed"/>
+                            <subject>
+                                <relatedSubject classCode="PRS">
+                                    <code code="BRO" displayName="Brother"
+                                        codeSystem="2.16.840.1.113883.5.111"
+                                        codeSystemName="HL7RoleCode"/>
+                                    <subject>
+                                        <sdtc:id root="1.3.6.1.4.1.21367.13.40.117"
+                                            extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"
+                                            xmlns:sdtc="urn:hl7-org:sdtc"/>
+                                        <name>Kenneth</name>
+                                        <administrativeGenderCode code="M" displayName="Male"
+                                            codeSystem="2.16.840.1.113883.5.1"
+                                            codeSystemName="HL7AdministrativeGender"/>
+                                        <birthTime nullFlavor="UNK"/>
+                                    </subject>
+                                </relatedSubject>
+                            </subject>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160445003" displayName="Alive and well"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_0"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="d1af37b2-178e-4cd9-ae47-3f63d9d6947f"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160377001" displayName="Family history of asthma"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_1"/>
+                                        </originalText>
+                                    </value>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.31"/>
+                                            <code code="445518008" displayName="Age At Onset"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT"/>
+                                            <statusCode code="completed"/>
+                                            <value value="16" unit="a" xsi:type="PQ"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Immunizations"/>
+                    <code code="11369-6" displayName="HISTORY OF IMMUNIZATION NARRATIVE"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Immunizations</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Vaccine</th>
+                                    <th>Date</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_0" xmlns="urn:hl7-org:v3"
+                                            >influenza, intradermal, quadrivalent, preservative
+                                            free, injectable</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>refused</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_0" xmlns="urn:hl7-org:v3"
+                                            >Note: Immunization was not given - Patient rejected
+                                            immunization. ; Source: New Immunization Record
+                                        </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_1" xmlns="urn:hl7-org:v3"
+                                            >diphtheria, tetanus toxoids and acellular pertussis
+                                            vaccine, 5 pertussis antigens</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-04-2012</content>
+                                    </td>
+                                    <td>
+                                        <content>administered</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_1" xmlns="urn:hl7-org:v3"
+                                            >Source: Source Unspecified </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="true">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="51f02998-93bb-4385-9050-873373b9fc44"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_0"/>
+                            </text>
+                            <statusCode code="aborted"/>
+                            <effectiveTime value="20150622"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="166"
+                                            displayName="influenza, intradermal, quadrivalent, preservative free, injectable"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_0"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK"/>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319185347"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706151004-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="ba7049e4-8bcb-4a44-84e8-9e3f40d28f5f"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20120104"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="106"
+                                            displayName="diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_1"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText>2</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319184655"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201705081257-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Payer"/>
+                    <code code="48768-6" displayName="PAYMENT SOURCES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Payers</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Payer name</th>
+                                    <th>Insurance type</th>
+                                    <th>Covered party ID</th>
+                                    <th>Authorization(s)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownPayer" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="SocialHistory"/>
+                    <code code="29762-2" displayName="SOCIAL HISTORY"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Social History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Description</th>
+                                    <th>Quantity</th>
+                                    <th>Date Captured</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_0" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_0"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_0"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_1" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_1"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_1"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_2" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Cigarette smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_2"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_3" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Current every day smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_3"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobacco_5"
+                                            xmlns="urn:hl7-org:v3">Smoking Tobacco Use
+                                            Details</content>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobaccoDate_5"
+                                            xmlns="urn:hl7-org:v3">Aug-17-2017</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_6" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_6"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_6"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_7" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_7"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_7"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_8" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_8"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_9" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_9"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_11" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_11"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_11"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_12"
+                                            xmlns="urn:hl7-org:v3">Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_12"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_12"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_13" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_13"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_14" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_14"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Birth Sex</content>
+                                    </td>
+                                    <td>
+                                        <content ID="BSex_value0" xmlns="urn:hl7-org:v3"
+                                            >Female</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_3"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20150622"/>
+                            <value code="449868002" displayName="Current every day smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_9"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200304"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_14"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200228"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_0"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_6"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_11"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe" extension="TobaccoUse"/>
+                            <code code="11367-0" displayName="History of tobacco use"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistoryTobacco_2"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value code="65568007" displayName="Cigarette smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_1"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_7"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_12"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="SmokingTobacco"/>
+                            <code code="229819007" displayName="Tobacco use and exposure"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistorySmokingTobacco_5"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20170817"/>
+                            </effectiveTime>
+                            <value xsi:type="ST">Cigarette: No Details Available Quantity Details -
+                                Cigarette: No Details Available </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708170737-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.200"
+                                extension="2016-06-01"/>
+                            <code code="76689-9" displayName="Sex Assigned At Birth"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#BSex_value0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1"
+                                codeSystemName="HL7AdministrativeGender" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BSex_value0"/>
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202104020755-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="VitalSigns"/>
+                    <code code="8716-3" displayName="VITAL SIGNS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Vital Signs</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date / Time:</th>
+                                    <th>Height</th>
+                                    <th>Weight</th>
+                                    <th>BMI</th>
+                                    <th>Pulse Rate</th>
+                                    <th>Blood Pressure</th>
+                                    <th>Temperature</th>
+                                    <th>Respiratory Rate</th>
+                                    <th>Body Surface Area</th>
+                                    <th>Head Circumference</th>
+                                    <th>Head Circ. Percentile</th>
+                                    <th>Wt./Len. Percentile</th>
+                                    <th>BMI percentile</th>
+                                    <th>Pulse Ox</th>
+                                    <th>Inhaled Ox</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015 10:05 AM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_0" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_0" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_0" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeartBeat_0" xmlns="urn:hl7-org:v3"
+                                            >80 /min</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_0"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_0" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsRespiratoryRate_0"
+                                            xmlns="urn:hl7-org:v3">18 /min</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsPulseOx_0" xmlns="urn:hl7-org:v3">95
+                                            %</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsInhaledOxyConc_0"
+                                            xmlns="urn:hl7-org:v3">36 %</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020 1:55 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_1" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_1" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_1" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_1"
+                                            xmlns="urn:hl7-org:v3">150/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_1" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020 1:59 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_2" xmlns="urn:hl7-org:v3"
+                                            >65.00 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_2" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (165.00 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_2" xmlns="urn:hl7-org:v3">27.46
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_2"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="201506221005-0400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201707271030-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_height_0"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_weight_0"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_systolic_0"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_diastolic_0"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="heart_rate_0"/>
+                                    <code code="8867-4" displayName="Heart Rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeartBeat_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="80" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_temperature_0"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="respiratory_rate_0"/>
+                                    <code code="9279-1" displayName="Respiratory rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsRespiratoryRate_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="18" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="sao2_%_blda_pulseox_0"/>
+                                    <code code="59408-5" displayName="SaO2 % BldA PulseOx"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsPulseOx_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="95" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="inhaled_oxygen_concentration_0"/>
+                                    <code code="3150-0" displayName="Inhaled Oxygen Concentration"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsInhaledOxyConc_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="36" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202003041355-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200304"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111850-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_height_1"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_weight_1"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_systolic_1"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="150" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_diastolic_1"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_temperature_1"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_mass_index_1"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202002281359-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174" extension="43"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281401-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_height_2"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_weight_2"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_systolic_2"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_diastolic_2"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_mass_index_2"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="27.46" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="ChiefComplaintAndReasonForVisit"/>
+                    <code code="46239-0" displayName="CHIEF COMPLAINT AND REASON FOR VISIT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Chief Complaint And Reason For Visit</title>
+                    <text>
+                        <paragraph>No Information</paragraph>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ReferralReason"/>
+                    <code code="42349-1" displayName="REASON FOR REFERRAL"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Reason For Referral</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Reason For Referral</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="1">
+                                        <content ID="UnknownReferral" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="PlanOfCare"/>
+                    <code code="18776-5" displayName="TREATMENT PLAN"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Plan Of Treatment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Action</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Radiology Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_0" xmlns="urn:hl7-org:v3">EKG
+                                            (93000), Scheduled for: Jun-23-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Lab Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_1" xmlns="urn:hl7-org:v3"
+                                            >Urinanalysis macro (dipstick) panel (81002), Scheduled
+                                            for: Jun-29-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="bdb795ab-6f6d-415e-956c-fb87940dd574"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#FutureOrder_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506230400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708151638-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="3f143484-5a7b-4aca-acab-1bf2f8539896"/>
+                            <code code="24357-6"
+                                displayName="Urinalysis macro (dipstick) panel - Urine"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#FutureOrder_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506291200"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201725-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HistoryOfPresentIllness"/>
+                    <code code="10164-2" displayName="HISTORY OF PRESENT ILLNESS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History Of Present Illness</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Date</th>
+                                    <th>Complaint</th>
+                                    <th>History Of Present Illness</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>The HTN started in 2015. The symptoms began
+                                            gradually. The severity has been described as being 6.
+                                            It is currently stable. Risk factors include inactive
+                                            lifestyle, obesity, sleep apnea and smoking. The
+                                            hypertension is exacerbated by anxiety. Associated
+                                            symptoms include fatigue and headache.</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FunctionalStatus"/>
+                    <code code="47420-5" displayName="Functional Status"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Functional Status</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Functional Assessment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>May-01-2005</content>
+                                    </td>
+                                    <td>
+                                        <content>Dependence on cane</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"
+                                extension="2014-06-09"/>
+                            <id nullFlavor="UNK"/>
+                            <code nullFlavor="NP"/>
+                            <statusCode code="completed"/>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"
+                                        extension="2014-06-09"/>
+                                    <id root="e942984a-f2fb-416e-80ce-d481c8b0fb71"/>
+                                    <code code="54522-8" displayName="Functional Status"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20050501"/>
+                                    <value code="105504002" displayName="Dependence on cane"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.128"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime nullFlavor="UNK"/>
+                                    <value nullFlavor="UNK" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CcdaMedicationsAdministered"/>
+                    <code code="29549-3" displayName="MEDICATION ADMINISTERED"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications Administered</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="UnknownMedicationAdministered"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Instructions"/>
+                    <code code="69730-0" displayName="INSTRUCTIONS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Instructions</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Instruction</th>
+                                    <th>Additional Information</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PatientInstruction_0" xmlns="urn:hl7-org:v3">i.
+                                            Get an EKG done on 6/23/2015. ii. Get a Chest X-ray done
+                                            on 6/23/2015 showing the Lower Respiratory Tract
+                                            Structure. iii. Take Clindamycin 300mg three times a day
+                                            as needed if pain does not subside. iv. Schedule follow
+                                            on visit with Neighborhood Physicians Practice on
+                                            7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Related to Fever - Finding</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act moodCode="INT" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="1d98f86c-5319-45d4-98fa-a26df91591dc"/>
+                            <code code="423564006" displayName="Provider Instructions for treatment"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+                            <text>
+                                <reference value="#PatientInstruction_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000"/>
+                            </effectiveTime>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Assessment"/>
+                    <code code="51848-0" displayName="ASSESSMENTS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Assessments</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Assessment</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Fever - Finding</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>impression</content>
+                                    </td>
+                                    <td>
+                                        <content>The patient was found to have fever and Dr Davis is
+                                            suspecting Anemia based on the patient history. So Dr
+                                            Davis asked the patient to closely monitor the
+                                            temperature and blood pressure and get admitted to
+                                            Community Health Hospitals if the fever does not subside
+                                            within a day. i. Get an EKG done on 6/23/2015. ii. Take
+                                            Clindamycin 300mg three times a day as needed if pain
+                                            does not subside. iii. Schedule follow on visit with
+                                            Neighborhood Physicians Practice on 7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Acute tonsillitis due to other specified
+                                            organisms</content>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.60"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Goals"/>
+                    <code code="61146-7" displayName="GOALS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Goals</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Goal</th>
+                                    <th>Type</th>
+                                    <th>Priority</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Fever</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_0" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occurring every few
+                                            weeks.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_1" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_2" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occuring every few
+                                            weeks</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_3" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="3b72c7a7-2b83-4e68-a1c9-bcc637fd389f"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occurring
+                                every few weeks.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="d2b8277e-2016-4489-b2db-34360fde0cd0"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="eff3999e-ad61-477c-864f-402b281924a3"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occuring
+                                every few weeks</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="41ccf5d4-05af-48f1-949d-659040b8a781"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="MedicalEquipment"/>
+                    <code code="46264-8" displayName="MEDICAL EQUIPMENT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medical Equipment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th>Device</th>
+                                    <th>Universal Device Identifier</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Device Status</th>
+                                    <th>Implantable Device Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ImplantableProcDev__0_0" xmlns="urn:hl7-org:v3"
+                                            >CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>(01)00643169007222(17)160128(21)BLC200461H</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.313"
+                                extension="2018-05-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code code="33216"
+                                displayName="Introduction of cardiac pacemaker system via vein"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"
+                                xsi:type="CE"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.310"
+                                        extension="2018-05-01"/>
+                                    <id root="2.16.840.1.113883.3.3719"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="FDA"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK">
+                                            <originalText>
+                                                <reference value="#ImplantableProcDev__0_0"/>
+                                            </originalText>
+                                        </code>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="2.16.840.1.113883.3.3719"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP">
+                                <organizer classCode="CLUSTER" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.311"
+                                        extension="2019-06-21"/>
+                                    <id extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        root="2.16.840.1.113883.3.3719"/>
+                                    <code code="74711-3" displayName="Unique Device Identifier"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.304"
+                                                extension="2019-06-21"/>
+                                            <code code="C101722" displayName="Primary DI Number"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value root="1.3.160" extension="00643169007222"
+                                                displayable="true" assigningAuthorityName="GS1"
+                                                xsi:type="II"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.318"
+                                                extension="2019-06-21"/>
+                                            <code code="C106044" displayName="MRI Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C113844"
+                                                displayName="Labeling does not contain MRI Safety Information"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.46"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.314"
+                                                extension="2019-06-21"/>
+                                            <code code="C160938" displayName="Latex Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C106038"
+                                                displayName="Not Made with Natural Rubber Latex"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.47"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.305"
+                                                extension="2019-06-21"/>
+                                            <code code="C160939"
+                                                displayName="Implantable Device Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C45329" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.48"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.306"
+                                                extension="2018-05-01"/>
+                                            <code code="UDI-00007" displayName="Device Status"
+                                                codeSystem="1.3.6.1.4.1.19376.1.4.1.6.5.290"
+                                                codeSystemName="UDI Observation Type"/>
+                                            <value code="active"
+                                                codeSystem="2.16.840.1.113883.4.642.3.199"
+                                                codeSystemName="Device Status" xsi:type="CD"/>
+                                        </observation>
+                                    </component>
+                                </organizer>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HealthConcerns"/>
+                    <code code="75310-3" displayName="HEALTH CONCERNS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Observation</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthStatusObs_0" xmlns="urn:hl7-org:v3"
+                                            >Chronically ill</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Concern</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_0" xmlns="urn:hl7-org:v3"
+                                            >Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_1" xmlns="urn:hl7-org:v3"
+                                            >Weight - 88.000 kg</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_2" xmlns="urn:hl7-org:v3"
+                                            >Fever - Finding - R50.9</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_3" xmlns="urn:hl7-org:v3">BMI
+                                            - 28.08 - Watch weight of patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_4" xmlns="urn:hl7-org:v3"
+                                            >Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_5" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_6" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_7" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_8" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="EVN" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5" extension="2014-06-09"/>
+                            <id root="45cf87bf-0952-4e7c-b049-ad19b435729e"/>
+                            <code code="11323-3" displayName="HEALTH STATUS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthStatusObs_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="161901003" displayName="Chronically ill"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111912-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c7dcddd1-8a45-4536-8975-9df72a77d474"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6c1d5761-3b89-4592-97ac-67905ef3e3d8"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="a30988e2-aab4-4ff7-8ac8-a286393f22fb"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061059-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_4"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061100-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="5214ea51-a323-4a9e-860d-7b8f688688cd"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_5"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="deda0b49-2996-411b-b9b9-e517db9bec04"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_6"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061057-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c5bb9c90-1562-42b4-a2c1-fcf7868443e5"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_7"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_8"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061058-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.500" extension="2019-07-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CareTeam"/>
+                    <code code="85847-2" displayName="PATIENT CARE TEAM"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Patient Care Teams</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Members</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_0" xmlns="urn:hl7-org:v3">Core
+                                            Team</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>nullified</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item> Kristin Allison.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_1" xmlns="urn:hl7-org:v3">Care Team
+                                            A</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>[Family medicine specialist] Albert Davis, 2472
+                                                Rocky Place, Beaverton, OR, 97006.</item>
+                                            <item>[grandfather] Rick Holler, 1357 Amber Dr,
+                                                Beaverton, OR, 97006.</item>
+                                            <item>[spouse] Matthew Newman, 1357 Amber Dr.,
+                                                Beaverton, OR, 97006.</item>
+                                            <item> Tracy Davis, 2472 Rocky Place, Beaverton, OR,
+                                                97006.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="5ae3655e-dfe0-4bf9-9ec3-b3693d6956f5"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_0"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="nullified"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101291121-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="9a7b1756-d0a6-4db9-93f9-260dbaa04dc7"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode nullFlavor="UNK"/>
+                                    <effectiveTime>
+                                        <low nullFlavor="UNK"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low nullFlavor="UNK"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id root="2.16.840.1.113883.4.6" extension="1528951720"/>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Allison</family>
+                                                  <given>Kristin</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="1755af9d-4c9f-4442-ac10-fc9d2b264338"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_1"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101191649-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="6ebb65ef-0d6f-4358-87da-96e4b71f8b4b"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="207Q00000X"
+                                                displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Neighborhood Physicians Practice</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="48563921-dded-4fc5-b54e-0b86775d7fca"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Holler</family>
+                                                  <given>Rick</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="335b6602-a8b2-4d3d-8744-9ad850e7ebc6"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Newman</family>
+                                                  <given>Matthew</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="b72378a1-6e51-4e33-a209-93374a095f12"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="251B00000X"
+                                                displayName="Agencies : Case Management"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Tracy</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="DischargeSummaryClinicalNotes"/>
+                    <code code="18842-5" displayName="Discharge summary"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Discharge Summary Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownDischargeSummaryClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="18842-5" displayName="Discharge summary"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownDischargeSummaryClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ConsultNoteClinicalNotes"/>
+                    <code code="11488-4" displayName="Consult Note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Consultation Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownConsultNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11488-4" displayName="Consult Note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownConsultNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="HistoryPhysicalNoteClinicalNotes"/>
+                    <code code="34117-2" displayName="History and physical note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History and Physical Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownHistoryPhysicalNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="34117-2" displayName="History and physical note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownHistoryPhysicalNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ProgressNoteNoteClinicalNotes"/>
+                    <code code="11506-3" displayName="Progress note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Progress Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_ProgressNoteNoteClinicalNotes_0"
+                                            xmlns="urn:hl7-org:v3">Ms Alice Newman seems to be
+                                            developing high fever and hence we recommend her to get
+                                            admitted to a nearby hospital using the provided
+                                            referral. </content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                        	<!--  Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11506-3" displayName="Progress note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_ProgressNoteNoteClinicalNotes_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210920"/>
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 INvalid TS as per provenance reqs, but is not provenance, so irrelevant, no error expected
+                                 -->
+                                <time value="20660920144244"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="9d7d931c-948f-4a59-a532-d9b96c868129"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331.xml
+++ b/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331.xml
@@ -1,0 +1,10364 @@
+<?xml version="1.0"?><?xml-stylesheet type='text/xsl' href='http://www.nextgenshare.com/public/CDA_NGMU2.xsl'?>
+<ClinicalDocument xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc"
+    xmlns="urn:hl7-org:v3" xmlns:mif="urn:hl7-org:v3/mif"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US"/>
+    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+    <id root="1.3.6.1.4.1.21367.13.40.117" extension="f0b0de8a-dfd1-458b-99a5-523011eba40b"/>
+    <code code="34133-9" displayName="SUMMARIZATION OF EPISODE NOTE"
+        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+    <title>Continuity of Care Document (C-CDA R2.1)</title>
+    <effectiveTime value="20210920164540-0400"/>
+    <confidentialityCode code="N" displayName="Normal Sharing" codeSystem="2.16.840.1.113883.5.25"
+        codeSystemName="HL7 Confidentiality"/>
+    <languageCode code="en-US"/>
+    <recordTarget>
+        <patientRole>
+            <id extension="8658" root="1.100"/>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom use="MC" value="tel:+1-5557771234"/>
+            <telecom use="HP" value="tel:+1-5557231544"/>
+            <telecom value="mailto:sadavis@nextgen.com"/>
+            <patient>
+                <name use="L">
+                    <family>Newman</family>
+                    <given qualifier="CL">Alice</given>
+                    <given>Jones</given>
+                </name>
+                <name use="SRCH">
+                    <family>Newman</family>
+                    <given qualifier="BR">Alicia</given>
+                </name>
+                <administrativeGenderCode code="F" displayName="Female"
+                    codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
+                <birthTime value="19700501"/>
+                <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicitys"/>
+                <sdtc:raceCode code="2108-9" displayName="European"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+                <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicitys"/>
+                <languageCommunication>
+                    <templateId root="2.16.840.1.113883.3.88.11.32.2"/>
+                    <languageCode code="en"/>
+                    <preferenceInd value="true"/>
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id root="1.174" extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+        </assignedAuthor>
+    </author>
+    <author>
+        <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id nullFlavor="UNK"/>
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom value="5555551002"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom value="5555551002"/>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <informant>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Admin</family>
+                    <given>NEXTGEN</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </informant>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <legalAuthenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom use="WP" nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </legalAuthenticator>
+    <authenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </authenticator>
+    <participant typeCode="IND">
+        <time value="19400101"/>
+        <associatedEntity classCode="PRS">
+            <code code="GRPRN" displayName="grandparent" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="04" displayName="Grandparent"
+                    codeSystem="2.16.840.1.113883.3.109" codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Holler</family>
+                    <given>Rick</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <time value="19790101"/>
+        <associatedEntity classCode="PRS">
+            <code code="SPS" displayName="spouse" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="01" displayName="Spouse" codeSystem="2.16.840.1.113883.3.109"
+                    codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Newman</family>
+                    <given>Matthew</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <associatedEntity classCode="CAREGIVER">
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+            </addr>
+            <telecom use="HP" value="tel:+1-5555551002"/>
+            <associatedPerson>
+                <name>
+                    <family>Allison</family>
+                    <given>Kristin</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <functionCode code="PCP" codeSystem="2.16.840.1.113883.5.88"/>
+        <associatedEntity classCode="CAREGIVER">
+            <associatedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <documentationOf typeCode="DOC">
+        <serviceEvent classCode="PCPR">
+            <effectiveTime>
+                <low value="201506221000"/>
+                <high value="202109201436"/>
+            </effectiveTime>
+            <performer typeCode="PRF">
+                <time>
+                    <low value="202109201645"/>
+                    <high value="202109201645"/>
+                </time>
+                <assignedEntity>
+                    <id root="1.174" extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"/>
+                    <addr>
+                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                        <city>Tripler Army Medical Center</city>
+                        <state>HI</state>
+                        <postalCode>96859-5000</postalCode>
+                        <country>US</country>
+                    </addr>
+                    <telecom nullFlavor="UNK"/>
+                    <assignedPerson>
+                        <name>
+                            <given>TerryThisIsAReallyLongFi</given>
+                            <family>HoitzThisIsAReallyLongLa</family>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </performer>
+        </serviceEvent>
+    </documentationOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Alerts"/>
+                    <code code="48765-2" displayName="Allergies and adverse reactions Document"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Allergies, Adverse Reactions, Alerts</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Substance</th>
+                                    <th>Reaction</th>
+                                    <th>Status</th>
+                                    <th>Criticality</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_0" xmlns="urn:hl7-org:v3"
+                                            >penicillin G </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_0_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_0_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_0" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_0" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_1" xmlns="urn:hl7-org:v3"
+                                            >ampicillin </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_1_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_1_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_1" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_1" xmlns="urn:hl7-org:v3"
+                                            >Low</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201810241352-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Canonica</family>
+                                                  <given>Gina</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="7980" displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_0"/>
+                                                  </originalText>
+                                                  <translation code="4977"
+                                                  displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>penicillin G</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_0_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_0_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_0_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101121613-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="733" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_1"/>
+                                                  </originalText>
+                                                  <translation code="2692" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>ampicillin</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_1_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_1_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_1_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="CRITL" displayName="Low"
+                                                codeSystem="2.16.840.1.113883.5.1063"
+                                                codeSystemName="HL7SeverityObservation"
+                                                xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Medications"/>
+                    <code code="10160-0" displayName="History of Medication use Narrative"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_0" xmlns="urn:hl7-org:v3"
+                                            >Aranesp 500 mcg/mL (in polysorbate) injection
+                                            syringe</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_0" xmlns="urn:hl7-org:v3">inject
+                                            1 milliliter by subcutaneous route every week</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_0" xmlns="urn:hl7-org:v3">2.25
+                                            MCG/KG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_1" xmlns="urn:hl7-org:v3"
+                                            >clindamycin 300 mg capsule</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_1" xmlns="urn:hl7-org:v3">take 1
+                                            capsule by oral route 3 times every day if pain does not
+                                            subside as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_1" xmlns="urn:hl7-org:v3">300
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-01-2017 - Oct-30-2018</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_2" xmlns="urn:hl7-org:v3"
+                                            >Tylenol Extra Strength 500 mg tablet</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_2" xmlns="urn:hl7-org:v3">take 1
+                                            tablet by oral route every 4 hours as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_2" xmlns="urn:hl7-org:v3">500
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jul-01-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_2" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_3" xmlns="urn:hl7-org:v3"
+                                            >ceftriaxone 100 gram solution for injection</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_3" xmlns="urn:hl7-org:v3">inject
+                                            10 milligram by injection route 2 times every
+                                            day</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_3" xmlns="urn:hl7-org:v3">10
+                                            milligram</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jun-30-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="5418eadb-2b53-4aa6-9875-2f918456f0fa"/>
+                            <text>
+                                <reference value="#MedicationSig_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="1" unit="wk"/>
+                            </effectiveTime>
+                            <routeCode code="C38299" displayName="SUBCUTANEOUS"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="mL"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="731241"
+                                            displayName="1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe [Aranesp]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_0"/>
+                                            </originalText>
+                                            <translation code="55513003201"
+                                                displayName="darbepoetin alfa in polysorbat"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe
+                                            [Aranesp]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706142020-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="ddd500c2-4399-4a50-addd-aa2c26fa3fdf"/>
+                            <text>
+                                <reference value="#MedicationSig_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20170901"/>
+                                <high value="20181030"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="true" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="8" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{capsule}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="748748"
+                                            displayName="clindamycin 300 MG Oral Capsule [Cleocin]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_1"/>
+                                            </originalText>
+                                            <translation code="00527138301"
+                                                displayName="clindamycin HCl"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>clindamycin 300 MG Oral Capsule [Cleocin]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170901"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201810241401-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="6936cfb5-ad96-457e-8a90-1d71fd7e71f9"/>
+                            <text>
+                                <reference value="#MedicationSig_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150701"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="4" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{tablet}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="209459"
+                                            displayName="acetaminophen 500 MG Oral Tablet [Tylenol]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_2"/>
+                                            </originalText>
+                                            <translation code="00450044406"
+                                                displayName="acetaminophen"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>acetaminophen 500 MG Oral Tablet [Tylenol]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101141402-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="f6552a8d-5ae6-42ce-a4a8-e86bcba51a7d"/>
+                            <text>
+                                <reference value="#MedicationSig_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150630"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="12" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38291" displayName="PARENTERAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="10" unit="mg"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="309090"
+                                            displayName="ceftriaxone 100 MG/ML Injectable Solution"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_3"/>
+                                            </originalText>
+                                            <translation code="66288610001"
+                                                displayName="ceftriaxone sodium"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201554-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Problems"/>
+                    <code code="11450-4" displayName="PROBLEM LIST"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Problems</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Condition</th>
+                                    <th>Type</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Clinical Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Chronic rejection of renal
+                                            transplant</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Overweight</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - Jun-01-2007</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Problem resolved
+                                            (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="dc419944-c4a3-4343-9782-7c3468b5be90"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="386661006" displayName="Fever"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202102081114-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="770ff05e-9f26-4245-a4e6-48c88b7a8a6e"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="236578006"
+                                        displayName="Chronic rejection of renal transplant"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111005"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="59621000" displayName="Essential hypertension"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111005"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems2"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="83986005" displayName="Severe hypothyroidism"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101191712-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems3"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems4"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                                <high value="20070601"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="cb229847-35f2-4d70-bc2d-b3713e82763d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high value="20070601"/>
+                                    </effectiveTime>
+                                    <value code="238131007" displayName="Overweight"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201705081255-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems4"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="413322009"
+                                                displayName="Problem resolved (finding)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+					<!-- Procedures Section -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Procedures"/>
+                    <code code="47519-4" displayName="HISTORY OF PROCEDURES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Procedures</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure</th>
+                                    <th>Universal Device Identifier/Device Identifier</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_0" xmlns="urn:hl7-org:v3"
+                                            >Nebulizer Therapy</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_1" xmlns="urn:hl7-org:v3"
+                                            >Introduction of cardiac pacemaker system via
+                                            vein</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4 -
+                                                (01)00643169007222(17)160128(21)BLC200461H</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_3" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_Procedures_0" xmlns="urn:hl7-org:v3"
+                                            >Dr Albert Davis examined Ms Alice Newman and found that
+                                            the pacemaker is operating properly and the
+                                            breathlessness is due to high fever and
+                                            anxiety.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="aaff7f65-82dc-4039-85ac-5db62a9d983e"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_0"/>
+                                </originalText>
+                                <translation code="94640" displayName="Nebulizer Therapy"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101112008-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_1"/>
+                                </originalText>
+                                <translation code="33216"
+                                    displayName="Introduction of cardiac pacemaker system via vein"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                                <high value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.37"/>
+                                    <id root="1.3.160"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="GS1"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK"/>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="1.3.160"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="ff884e65-94e1-4e11-9438-74b67d03da41"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_2"/>
+                                </originalText>
+                                <translation code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                                <high value="20200304"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041448-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="07250fe9-b4ac-485f-b42d-3dff1df1ddd8"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_3"/>
+                                </originalText>
+                                <translation code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                                <high value="20200228"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281407-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+							<!-- Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<!-- relevant identifying code 28570-0 in error -->
+                                <translation code="28570-0" displayName="Procedure note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_Procedures_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+							<!-- swapped authors so provenance is first and author participation is 2nd -->
+                            <author>
+								<!-- Provenance = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- this time should now show up as a valid provenance error as is provenance and has no time-zone -->
+                                <time value="20210125145611"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+								<!-- -dbTest 1 - update to be INvalid (but not provenance anyway -->
+                                <time value="20660125145611"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>                            
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Results"/>
+                    <code code="30954-2"
+                        displayName="Relevant diagnostic tests &amp;or laboratory data"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Results</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Test Name</th>
+                                    <th>Date and Time</th>
+                                    <th>Measure</th>
+                                    <th>Units</th>
+                                    <th>Reference Range</th>
+                                    <th>Abnormal Flag</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_0" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Urinanalysis macro (dipstick)
+                                            panel</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_0" xmlns="urn:hl7-org:v3"
+                                            >SPECIMEN: source: Urine specimen, Urine</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_0" xmlns="urn:hl7-org:v3"
+                                            >Color of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_0"
+                                            xmlns="urn:hl7-org:v3">YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_0" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_1" xmlns="urn:hl7-org:v3"
+                                            >Appearance of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_1"
+                                            xmlns="urn:hl7-org:v3">CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_1" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_2" xmlns="urn:hl7-org:v3"
+                                            >Specific gravity of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>1.015</content>
+                                    </td>
+                                    <td>
+                                        <content>1</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_2"
+                                            xmlns="urn:hl7-org:v3">1.005-1.030</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_2" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_3" xmlns="urn:hl7-org:v3"
+                                            >pH of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>5.0</content>
+                                    </td>
+                                    <td>
+                                        <content>pH</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_3"
+                                            xmlns="urn:hl7-org:v3">5.0-8.0</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_3" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_4" xmlns="urn:hl7-org:v3"
+                                            >Glucose [Mass/volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>50</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_4"
+                                            xmlns="urn:hl7-org:v3">Neg</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_4" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_5" xmlns="urn:hl7-org:v3"
+                                            >Ketones [Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_5"
+                                            xmlns="urn:hl7-org:v3">Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_5" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_6" xmlns="urn:hl7-org:v3"
+                                            >Protein[Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>100</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_6"
+                                            xmlns="urn:hl7-org:v3">negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_6" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_1" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Chest X-ray 2 views</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_1_0" xmlns="urn:hl7-org:v3"
+                                            >Chest X-ray 2 Views</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 21:54:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Abnormal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_1_0"
+                                            xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>A</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_1_0" xmlns="urn:hl7-org:v3">Lungs
+                                            are not clear, cannot rule out Anemia. Other tests are
+                                            required to determine the presence or absence of Anemia.
+                                        </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note Type</th>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Laboratory Report Narrative</content>
+                                    </td>
+                                    <td>
+                                        <content ID="clinNotes_Results_0" xmlns="urn:hl7-org:v3">Ms
+                                            Alice Newman was tested for the Urinanalysis macro panel
+                                            and the results have been found to be normal.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="f05926e4-90b4-4d39-b7db-46c5ae2c28bf"/>
+                            <code code="24357-6" displayName="Urinanalysis macro (dipstick) panel"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_0"/>
+                                </originalText>
+                                <translation code="81002"
+                                    displayName="Urinalysis, non-automated, w/scope"
+                                    codeSystemName="L"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000-0400"/>
+                                <high value="20150622110000-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622110000"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706301717-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Interface</family>
+                                            <given>Rosetta</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5778-6" displayName="Color of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">YELLOW</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>YELLOW</text>
+                                            <value xsi:type="ST">YELLOW</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5767-9" displayName="Appearance of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">CLEAR</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>CLEAR</text>
+                                            <value xsi:type="ST">CLEAR</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5811-5"
+                                        displayName="Specific gravity of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="1.015" unit="1"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>1.005-1.030</text>
+                                            <value xsi:type="ST">1.005-1.030</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5803-2" displayName="pH of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="5.0" unit="[pH]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>5.0-8.0</text>
+                                            <value xsi:type="ST">5.0-8.0</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5792-7"
+                                        displayName="Glucose [Mass/volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="50" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Neg</text>
+                                            <value xsi:type="ST">Neg</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5797-6"
+                                        displayName="Ketones [Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_5"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">Negative</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Negative</text>
+                                            <value xsi:type="ST">Negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5804-0"
+                                        displayName="Protein[Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_6"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="100" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>negative</text>
+                                            <value xsi:type="ST">negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="5f09fddb-1a80-4a65-8d24-8a2a08637f09"/>
+                            <code code="36643-5" displayName="Chest X-ray 2 views"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_1"/>
+                                </originalText>
+                                <translation code="71010" displayName="Chest X-ray"
+                                    codeSystemName="R"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622115900-0400"/>
+                                <high value="20150622115900-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622115900"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706281613-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="36643-5" displayName="Chest X-ray 2 Views"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_1_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622215400-0400"/>
+                                    <value xsi:type="ST">Abnormal</value>
+                                    <interpretationCode code="A" displayName="Abnormal"
+                                        codeSystem="2.16.840.1.113883.5.83"
+                                        codeSystemName="HL7 Observation Interpretation"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622115900"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706281613-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>User</family>
+                                                  <given>Adam</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                            <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ResultComment_1_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                        </act>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#clinNotes_Results_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20210125145624"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="AdvanceDirectives"/>
+                    <code code="42348-3" displayName="ADVANCE DIRECTIVES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Advance Directives</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Directive</th>
+                                    <th>Yes / No</th>
+                                    <th>Effective Date</th>
+                                    <th>File Name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownAdvanceDirective" xmlns="urn:hl7-org:v3"
+                                            >No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Encounters"/>
+                    <code code="46240-8" displayName="HISTORY OF ENCOUNTERS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Encounters</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Description</th>
+                                    <th>Practice</th>
+                                    <th>Location</th>
+                                    <th>Reason(s) For Visit</th>
+                                    <th>Diagnoses</th>
+                                    <th>Date</th>
+                                    <th>Provider</th>
+                                    <th>Providers Copied on Encounter</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                    <td>
+                                        <content>HoitzThisIsAReallyLongLa TerryThisIsAReallyLongFi.
+                                            1 Jarrett White Rd, Tripler Army Medical Center, HI,
+                                            968595000, US. tel:+1-8084331212</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_1" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>
+                                                <content>sore throat (chief complaint)</content>
+                                            </item>
+                                            <item>
+                                                <content>Sore throat (chief complaint)</content>
+                                            </item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Acute tonsillitis due to other specified
+                                                organisms</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension (chief complaint)</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Hypertension</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Fever - Finding</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="9d7d931c-948f-4a59-a532-d9b96c868129"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_0"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202109201436"/>
+                                <high value="202109201436"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                                        <city>Tripler Army Medical Center</city>
+                                        <state>HI</state>
+                                        <postalCode>96859-5000</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-8084331212"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>HoitzThisIsAReallyLongLa</family>
+                                            <given>TerryThisIsAReallyLongFi</given>
+                                            <given>TerrysMiddleName-35-</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id nullFlavor="UNK"/>
+                                            <code nullFlavor="UNK">
+                                                <translation nullFlavor="UNK"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"/>
+                            <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_1"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202003041348"/>
+                                <high value="202003041348"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200304"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_1"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="285533fa-4983-4e30-b718-c2942646ea36"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="J03.80"
+                                                displayName="Acute tonsillitis due to other specified organisms"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time nullFlavor="UNK"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202003041440-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="26db8415-1153-455c-a328-da1aeb35e30f"/>
+                            <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_2"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202002281351"/>
+                                <high value="202002281351"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200228"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_2"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="5ad6f921-233e-4d8c-927d-ecfd26bfbaf9"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20200228"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="I10" displayName="Hypertension"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20200228"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202002281406-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_3"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="201506221000"/>
+                                <high value="201506221000"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                            <code code="~" displayName="~"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation nullFlavor="NA"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20150622"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="R50.9" displayName="Fever - Finding"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20150622"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202103261221-0400"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom value="5555551002"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FamilyHistory"/>
+                    <code code="10157-6" displayName="HISTORY OF FAMILY MEMBER DISEASES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Family History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Family Member</th>
+                                    <th>Type</th>
+                                    <th>Diagnosis</th>
+                                    <th>Age At Onset</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_0"
+                                            xmlns="urn:hl7-org:v3">Alive and well</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_1"
+                                            xmlns="urn:hl7-org:v3">Family history of
+                                            asthma</content>
+                                    </td>
+                                    <td>
+                                        <content>16</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"
+                                extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <statusCode code="completed"/>
+                            <subject>
+                                <relatedSubject classCode="PRS">
+                                    <code code="BRO" displayName="Brother"
+                                        codeSystem="2.16.840.1.113883.5.111"
+                                        codeSystemName="HL7RoleCode"/>
+                                    <subject>
+                                        <sdtc:id root="1.3.6.1.4.1.21367.13.40.117"
+                                            extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"
+                                            xmlns:sdtc="urn:hl7-org:sdtc"/>
+                                        <name>Kenneth</name>
+                                        <administrativeGenderCode code="M" displayName="Male"
+                                            codeSystem="2.16.840.1.113883.5.1"
+                                            codeSystemName="HL7AdministrativeGender"/>
+                                        <birthTime nullFlavor="UNK"/>
+                                    </subject>
+                                </relatedSubject>
+                            </subject>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160445003" displayName="Alive and well"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_0"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="d1af37b2-178e-4cd9-ae47-3f63d9d6947f"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160377001" displayName="Family history of asthma"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_1"/>
+                                        </originalText>
+                                    </value>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.31"/>
+                                            <code code="445518008" displayName="Age At Onset"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT"/>
+                                            <statusCode code="completed"/>
+                                            <value value="16" unit="a" xsi:type="PQ"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Immunizations"/>
+                    <code code="11369-6" displayName="HISTORY OF IMMUNIZATION NARRATIVE"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Immunizations</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Vaccine</th>
+                                    <th>Date</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_0" xmlns="urn:hl7-org:v3"
+                                            >influenza, intradermal, quadrivalent, preservative
+                                            free, injectable</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>refused</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_0" xmlns="urn:hl7-org:v3"
+                                            >Note: Immunization was not given - Patient rejected
+                                            immunization. ; Source: New Immunization Record
+                                        </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_1" xmlns="urn:hl7-org:v3"
+                                            >diphtheria, tetanus toxoids and acellular pertussis
+                                            vaccine, 5 pertussis antigens</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-04-2012</content>
+                                    </td>
+                                    <td>
+                                        <content>administered</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_1" xmlns="urn:hl7-org:v3"
+                                            >Source: Source Unspecified </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="true">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="51f02998-93bb-4385-9050-873373b9fc44"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_0"/>
+                            </text>
+                            <statusCode code="aborted"/>
+                            <effectiveTime value="20150622"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="166"
+                                            displayName="influenza, intradermal, quadrivalent, preservative free, injectable"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_0"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK"/>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319185347"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706151004-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="ba7049e4-8bcb-4a44-84e8-9e3f40d28f5f"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20120104"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="106"
+                                            displayName="diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_1"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText>2</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319184655"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201705081257-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Payer"/>
+                    <code code="48768-6" displayName="PAYMENT SOURCES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Payers</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Payer name</th>
+                                    <th>Insurance type</th>
+                                    <th>Covered party ID</th>
+                                    <th>Authorization(s)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownPayer" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="SocialHistory"/>
+                    <code code="29762-2" displayName="SOCIAL HISTORY"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Social History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Description</th>
+                                    <th>Quantity</th>
+                                    <th>Date Captured</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_0" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_0"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_0"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_1" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_1"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_1"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_2" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Cigarette smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_2"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_3" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Current every day smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_3"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobacco_5"
+                                            xmlns="urn:hl7-org:v3">Smoking Tobacco Use
+                                            Details</content>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobaccoDate_5"
+                                            xmlns="urn:hl7-org:v3">Aug-17-2017</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_6" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_6"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_6"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_7" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_7"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_7"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_8" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_8"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_9" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_9"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_11" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_11"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_11"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_12"
+                                            xmlns="urn:hl7-org:v3">Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_12"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_12"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_13" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_13"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_14" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_14"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Birth Sex</content>
+                                    </td>
+                                    <td>
+                                        <content ID="BSex_value0" xmlns="urn:hl7-org:v3"
+                                            >Female</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_3"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20150622"/>
+                            <value code="449868002" displayName="Current every day smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_9"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200304"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_14"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200228"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_0"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_6"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_11"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe" extension="TobaccoUse"/>
+                            <code code="11367-0" displayName="History of tobacco use"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistoryTobacco_2"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value code="65568007" displayName="Cigarette smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_1"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_7"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_12"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="SmokingTobacco"/>
+                            <code code="229819007" displayName="Tobacco use and exposure"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistorySmokingTobacco_5"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20170817"/>
+                            </effectiveTime>
+                            <value xsi:type="ST">Cigarette: No Details Available Quantity Details -
+                                Cigarette: No Details Available </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708170737-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.200"
+                                extension="2016-06-01"/>
+                            <code code="76689-9" displayName="Sex Assigned At Birth"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#BSex_value0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1"
+                                codeSystemName="HL7AdministrativeGender" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BSex_value0"/>
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202104020755-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="VitalSigns"/>
+                    <code code="8716-3" displayName="VITAL SIGNS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Vital Signs</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date / Time:</th>
+                                    <th>Height</th>
+                                    <th>Weight</th>
+                                    <th>BMI</th>
+                                    <th>Pulse Rate</th>
+                                    <th>Blood Pressure</th>
+                                    <th>Temperature</th>
+                                    <th>Respiratory Rate</th>
+                                    <th>Body Surface Area</th>
+                                    <th>Head Circumference</th>
+                                    <th>Head Circ. Percentile</th>
+                                    <th>Wt./Len. Percentile</th>
+                                    <th>BMI percentile</th>
+                                    <th>Pulse Ox</th>
+                                    <th>Inhaled Ox</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015 10:05 AM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_0" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_0" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_0" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeartBeat_0" xmlns="urn:hl7-org:v3"
+                                            >80 /min</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_0"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_0" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsRespiratoryRate_0"
+                                            xmlns="urn:hl7-org:v3">18 /min</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsPulseOx_0" xmlns="urn:hl7-org:v3">95
+                                            %</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsInhaledOxyConc_0"
+                                            xmlns="urn:hl7-org:v3">36 %</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020 1:55 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_1" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_1" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_1" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_1"
+                                            xmlns="urn:hl7-org:v3">150/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_1" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020 1:59 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_2" xmlns="urn:hl7-org:v3"
+                                            >65.00 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_2" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (165.00 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_2" xmlns="urn:hl7-org:v3">27.46
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_2"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="201506221005-0400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201707271030-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_height_0"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_weight_0"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_systolic_0"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_diastolic_0"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="heart_rate_0"/>
+                                    <code code="8867-4" displayName="Heart Rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeartBeat_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="80" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_temperature_0"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="respiratory_rate_0"/>
+                                    <code code="9279-1" displayName="Respiratory rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsRespiratoryRate_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="18" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="sao2_%_blda_pulseox_0"/>
+                                    <code code="59408-5" displayName="SaO2 % BldA PulseOx"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsPulseOx_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="95" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="inhaled_oxygen_concentration_0"/>
+                                    <code code="3150-0" displayName="Inhaled Oxygen Concentration"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsInhaledOxyConc_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="36" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202003041355-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200304"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111850-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_height_1"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_weight_1"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_systolic_1"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="150" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_diastolic_1"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_temperature_1"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_mass_index_1"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202002281359-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174" extension="43"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281401-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_height_2"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_weight_2"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_systolic_2"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_diastolic_2"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_mass_index_2"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="27.46" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="ChiefComplaintAndReasonForVisit"/>
+                    <code code="46239-0" displayName="CHIEF COMPLAINT AND REASON FOR VISIT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Chief Complaint And Reason For Visit</title>
+                    <text>
+                        <paragraph>No Information</paragraph>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ReferralReason"/>
+                    <code code="42349-1" displayName="REASON FOR REFERRAL"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Reason For Referral</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Reason For Referral</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="1">
+                                        <content ID="UnknownReferral" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="PlanOfCare"/>
+                    <code code="18776-5" displayName="TREATMENT PLAN"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Plan Of Treatment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Action</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Radiology Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_0" xmlns="urn:hl7-org:v3">EKG
+                                            (93000), Scheduled for: Jun-23-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Lab Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_1" xmlns="urn:hl7-org:v3"
+                                            >Urinanalysis macro (dipstick) panel (81002), Scheduled
+                                            for: Jun-29-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="bdb795ab-6f6d-415e-956c-fb87940dd574"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#FutureOrder_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506230400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708151638-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="3f143484-5a7b-4aca-acab-1bf2f8539896"/>
+                            <code code="24357-6"
+                                displayName="Urinalysis macro (dipstick) panel - Urine"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#FutureOrder_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506291200"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201725-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HistoryOfPresentIllness"/>
+                    <code code="10164-2" displayName="HISTORY OF PRESENT ILLNESS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History Of Present Illness</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Date</th>
+                                    <th>Complaint</th>
+                                    <th>History Of Present Illness</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>The HTN started in 2015. The symptoms began
+                                            gradually. The severity has been described as being 6.
+                                            It is currently stable. Risk factors include inactive
+                                            lifestyle, obesity, sleep apnea and smoking. The
+                                            hypertension is exacerbated by anxiety. Associated
+                                            symptoms include fatigue and headache.</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FunctionalStatus"/>
+                    <code code="47420-5" displayName="Functional Status"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Functional Status</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Functional Assessment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>May-01-2005</content>
+                                    </td>
+                                    <td>
+                                        <content>Dependence on cane</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"
+                                extension="2014-06-09"/>
+                            <id nullFlavor="UNK"/>
+                            <code nullFlavor="NP"/>
+                            <statusCode code="completed"/>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"
+                                        extension="2014-06-09"/>
+                                    <id root="e942984a-f2fb-416e-80ce-d481c8b0fb71"/>
+                                    <code code="54522-8" displayName="Functional Status"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20050501"/>
+                                    <value code="105504002" displayName="Dependence on cane"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.128"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime nullFlavor="UNK"/>
+                                    <value nullFlavor="UNK" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CcdaMedicationsAdministered"/>
+                    <code code="29549-3" displayName="MEDICATION ADMINISTERED"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications Administered</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="UnknownMedicationAdministered"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Instructions"/>
+                    <code code="69730-0" displayName="INSTRUCTIONS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Instructions</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Instruction</th>
+                                    <th>Additional Information</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PatientInstruction_0" xmlns="urn:hl7-org:v3">i.
+                                            Get an EKG done on 6/23/2015. ii. Get a Chest X-ray done
+                                            on 6/23/2015 showing the Lower Respiratory Tract
+                                            Structure. iii. Take Clindamycin 300mg three times a day
+                                            as needed if pain does not subside. iv. Schedule follow
+                                            on visit with Neighborhood Physicians Practice on
+                                            7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Related to Fever - Finding</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act moodCode="INT" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="1d98f86c-5319-45d4-98fa-a26df91591dc"/>
+                            <code code="423564006" displayName="Provider Instructions for treatment"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+                            <text>
+                                <reference value="#PatientInstruction_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000"/>
+                            </effectiveTime>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Assessment"/>
+                    <code code="51848-0" displayName="ASSESSMENTS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Assessments</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Assessment</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Fever - Finding</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>impression</content>
+                                    </td>
+                                    <td>
+                                        <content>The patient was found to have fever and Dr Davis is
+                                            suspecting Anemia based on the patient history. So Dr
+                                            Davis asked the patient to closely monitor the
+                                            temperature and blood pressure and get admitted to
+                                            Community Health Hospitals if the fever does not subside
+                                            within a day. i. Get an EKG done on 6/23/2015. ii. Take
+                                            Clindamycin 300mg three times a day as needed if pain
+                                            does not subside. iii. Schedule follow on visit with
+                                            Neighborhood Physicians Practice on 7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Acute tonsillitis due to other specified
+                                            organisms</content>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.60"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Goals"/>
+                    <code code="61146-7" displayName="GOALS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Goals</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Goal</th>
+                                    <th>Type</th>
+                                    <th>Priority</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Fever</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_0" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occurring every few
+                                            weeks.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_1" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_2" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occuring every few
+                                            weeks</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_3" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="3b72c7a7-2b83-4e68-a1c9-bcc637fd389f"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occurring
+                                every few weeks.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="d2b8277e-2016-4489-b2db-34360fde0cd0"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="eff3999e-ad61-477c-864f-402b281924a3"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occuring
+                                every few weeks</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="41ccf5d4-05af-48f1-949d-659040b8a781"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="MedicalEquipment"/>
+                    <code code="46264-8" displayName="MEDICAL EQUIPMENT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medical Equipment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th>Device</th>
+                                    <th>Universal Device Identifier</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Device Status</th>
+                                    <th>Implantable Device Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ImplantableProcDev__0_0" xmlns="urn:hl7-org:v3"
+                                            >CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>(01)00643169007222(17)160128(21)BLC200461H</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.313"
+                                extension="2018-05-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code code="33216"
+                                displayName="Introduction of cardiac pacemaker system via vein"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"
+                                xsi:type="CE"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.310"
+                                        extension="2018-05-01"/>
+                                    <id root="2.16.840.1.113883.3.3719"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="FDA"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK">
+                                            <originalText>
+                                                <reference value="#ImplantableProcDev__0_0"/>
+                                            </originalText>
+                                        </code>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="2.16.840.1.113883.3.3719"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP">
+                                <organizer classCode="CLUSTER" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.311"
+                                        extension="2019-06-21"/>
+                                    <id extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        root="2.16.840.1.113883.3.3719"/>
+                                    <code code="74711-3" displayName="Unique Device Identifier"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.304"
+                                                extension="2019-06-21"/>
+                                            <code code="C101722" displayName="Primary DI Number"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value root="1.3.160" extension="00643169007222"
+                                                displayable="true" assigningAuthorityName="GS1"
+                                                xsi:type="II"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.318"
+                                                extension="2019-06-21"/>
+                                            <code code="C106044" displayName="MRI Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C113844"
+                                                displayName="Labeling does not contain MRI Safety Information"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.46"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.314"
+                                                extension="2019-06-21"/>
+                                            <code code="C160938" displayName="Latex Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C106038"
+                                                displayName="Not Made with Natural Rubber Latex"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.47"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.305"
+                                                extension="2019-06-21"/>
+                                            <code code="C160939"
+                                                displayName="Implantable Device Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C45329" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.48"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.306"
+                                                extension="2018-05-01"/>
+                                            <code code="UDI-00007" displayName="Device Status"
+                                                codeSystem="1.3.6.1.4.1.19376.1.4.1.6.5.290"
+                                                codeSystemName="UDI Observation Type"/>
+                                            <value code="active"
+                                                codeSystem="2.16.840.1.113883.4.642.3.199"
+                                                codeSystemName="Device Status" xsi:type="CD"/>
+                                        </observation>
+                                    </component>
+                                </organizer>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HealthConcerns"/>
+                    <code code="75310-3" displayName="HEALTH CONCERNS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Observation</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthStatusObs_0" xmlns="urn:hl7-org:v3"
+                                            >Chronically ill</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Concern</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_0" xmlns="urn:hl7-org:v3"
+                                            >Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_1" xmlns="urn:hl7-org:v3"
+                                            >Weight - 88.000 kg</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_2" xmlns="urn:hl7-org:v3"
+                                            >Fever - Finding - R50.9</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_3" xmlns="urn:hl7-org:v3">BMI
+                                            - 28.08 - Watch weight of patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_4" xmlns="urn:hl7-org:v3"
+                                            >Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_5" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_6" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_7" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_8" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="EVN" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5" extension="2014-06-09"/>
+                            <id root="45cf87bf-0952-4e7c-b049-ad19b435729e"/>
+                            <code code="11323-3" displayName="HEALTH STATUS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthStatusObs_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="161901003" displayName="Chronically ill"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111912-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c7dcddd1-8a45-4536-8975-9df72a77d474"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6c1d5761-3b89-4592-97ac-67905ef3e3d8"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="a30988e2-aab4-4ff7-8ac8-a286393f22fb"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061059-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_4"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061100-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="5214ea51-a323-4a9e-860d-7b8f688688cd"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_5"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="deda0b49-2996-411b-b9b9-e517db9bec04"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_6"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061057-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c5bb9c90-1562-42b4-a2c1-fcf7868443e5"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_7"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_8"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061058-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.500" extension="2019-07-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CareTeam"/>
+                    <code code="85847-2" displayName="PATIENT CARE TEAM"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Patient Care Teams</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Members</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_0" xmlns="urn:hl7-org:v3">Core
+                                            Team</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>nullified</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item> Kristin Allison.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_1" xmlns="urn:hl7-org:v3">Care Team
+                                            A</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>[Family medicine specialist] Albert Davis, 2472
+                                                Rocky Place, Beaverton, OR, 97006.</item>
+                                            <item>[grandfather] Rick Holler, 1357 Amber Dr,
+                                                Beaverton, OR, 97006.</item>
+                                            <item>[spouse] Matthew Newman, 1357 Amber Dr.,
+                                                Beaverton, OR, 97006.</item>
+                                            <item> Tracy Davis, 2472 Rocky Place, Beaverton, OR,
+                                                97006.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="5ae3655e-dfe0-4bf9-9ec3-b3693d6956f5"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_0"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="nullified"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101291121-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="9a7b1756-d0a6-4db9-93f9-260dbaa04dc7"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode nullFlavor="UNK"/>
+                                    <effectiveTime>
+                                        <low nullFlavor="UNK"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low nullFlavor="UNK"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id root="2.16.840.1.113883.4.6" extension="1528951720"/>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Allison</family>
+                                                  <given>Kristin</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="1755af9d-4c9f-4442-ac10-fc9d2b264338"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_1"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101191649-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="6ebb65ef-0d6f-4358-87da-96e4b71f8b4b"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="207Q00000X"
+                                                displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Neighborhood Physicians Practice</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="48563921-dded-4fc5-b54e-0b86775d7fca"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Holler</family>
+                                                  <given>Rick</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="335b6602-a8b2-4d3d-8744-9ad850e7ebc6"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Newman</family>
+                                                  <given>Matthew</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="b72378a1-6e51-4e33-a209-93374a095f12"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="251B00000X"
+                                                displayName="Agencies : Case Management"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Tracy</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="DischargeSummaryClinicalNotes"/>
+                    <code code="18842-5" displayName="Discharge summary"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Discharge Summary Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownDischargeSummaryClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="18842-5" displayName="Discharge summary"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownDischargeSummaryClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ConsultNoteClinicalNotes"/>
+                    <code code="11488-4" displayName="Consult Note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Consultation Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownConsultNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11488-4" displayName="Consult Note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownConsultNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="HistoryPhysicalNoteClinicalNotes"/>
+                    <code code="34117-2" displayName="History and physical note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History and Physical Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownHistoryPhysicalNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="34117-2" displayName="History and physical note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownHistoryPhysicalNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ProgressNoteNoteClinicalNotes"/>
+                    <code code="11506-3" displayName="Progress note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Progress Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_ProgressNoteNoteClinicalNotes_0"
+                                            xmlns="urn:hl7-org:v3">Ms Alice Newman seems to be
+                                            developing high fever and hence we recommend her to get
+                                            admitted to a nearby hospital using the provided
+                                            referral. </content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                        	<!--  Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11506-3" displayName="Progress note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_ProgressNoteNoteClinicalNotes_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210920"/>
+							<!-- swapped authors so provenance is first and author participation is 2nd -->                            
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 INvalid TS as per provenance reqs, but is not provenance, so irrelevant, no error expected
+                                 -->
+                                <time value="20660920144244"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>                            
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="9d7d931c-948f-4a59-a532-d9b96c868129"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
+++ b/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
@@ -1,0 +1,10362 @@
+<?xml version="1.0"?><?xml-stylesheet type='text/xsl' href='http://www.nextgenshare.com/public/CDA_NGMU2.xsl'?>
+<ClinicalDocument xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc"
+    xmlns="urn:hl7-org:v3" xmlns:mif="urn:hl7-org:v3/mif"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US"/>
+    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+    <id root="1.3.6.1.4.1.21367.13.40.117" extension="f0b0de8a-dfd1-458b-99a5-523011eba40b"/>
+    <code code="34133-9" displayName="SUMMARIZATION OF EPISODE NOTE"
+        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+    <title>Continuity of Care Document (C-CDA R2.1)</title>
+    <effectiveTime value="20210920164540-0400"/>
+    <confidentialityCode code="N" displayName="Normal Sharing" codeSystem="2.16.840.1.113883.5.25"
+        codeSystemName="HL7 Confidentiality"/>
+    <languageCode code="en-US"/>
+    <recordTarget>
+        <patientRole>
+            <id extension="8658" root="1.100"/>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom use="MC" value="tel:+1-5557771234"/>
+            <telecom use="HP" value="tel:+1-5557231544"/>
+            <telecom value="mailto:sadavis@nextgen.com"/>
+            <patient>
+                <name use="L">
+                    <family>Newman</family>
+                    <given qualifier="CL">Alice</given>
+                    <given>Jones</given>
+                </name>
+                <name use="SRCH">
+                    <family>Newman</family>
+                    <given qualifier="BR">Alicia</given>
+                </name>
+                <administrativeGenderCode code="F" displayName="Female"
+                    codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
+                <birthTime value="19700501"/>
+                <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicitys"/>
+                <sdtc:raceCode code="2108-9" displayName="European"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+                <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicitys"/>
+                <languageCommunication>
+                    <templateId root="2.16.840.1.113883.3.88.11.32.2"/>
+                    <languageCode code="en"/>
+                    <preferenceInd value="true"/>
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id root="1.174" extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+        </assignedAuthor>
+    </author>
+    <author>
+        <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id nullFlavor="UNK"/>
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom value="5555551002"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom value="5555551002"/>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <informant>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Admin</family>
+                    <given>NEXTGEN</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </informant>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <legalAuthenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom use="WP" nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </legalAuthenticator>
+    <authenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </authenticator>
+    <participant typeCode="IND">
+        <time value="19400101"/>
+        <associatedEntity classCode="PRS">
+            <code code="GRPRN" displayName="grandparent" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="04" displayName="Grandparent"
+                    codeSystem="2.16.840.1.113883.3.109" codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Holler</family>
+                    <given>Rick</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <time value="19790101"/>
+        <associatedEntity classCode="PRS">
+            <code code="SPS" displayName="spouse" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="01" displayName="Spouse" codeSystem="2.16.840.1.113883.3.109"
+                    codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Newman</family>
+                    <given>Matthew</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <associatedEntity classCode="CAREGIVER">
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+            </addr>
+            <telecom use="HP" value="tel:+1-5555551002"/>
+            <associatedPerson>
+                <name>
+                    <family>Allison</family>
+                    <given>Kristin</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <functionCode code="PCP" codeSystem="2.16.840.1.113883.5.88"/>
+        <associatedEntity classCode="CAREGIVER">
+            <associatedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <documentationOf typeCode="DOC">
+        <serviceEvent classCode="PCPR">
+            <effectiveTime>
+                <low value="201506221000"/>
+                <high value="202109201436"/>
+            </effectiveTime>
+            <performer typeCode="PRF">
+                <time>
+                    <low value="202109201645"/>
+                    <high value="202109201645"/>
+                </time>
+                <assignedEntity>
+                    <id root="1.174" extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"/>
+                    <addr>
+                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                        <city>Tripler Army Medical Center</city>
+                        <state>HI</state>
+                        <postalCode>96859-5000</postalCode>
+                        <country>US</country>
+                    </addr>
+                    <telecom nullFlavor="UNK"/>
+                    <assignedPerson>
+                        <name>
+                            <given>TerryThisIsAReallyLongFi</given>
+                            <family>HoitzThisIsAReallyLongLa</family>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </performer>
+        </serviceEvent>
+    </documentationOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Alerts"/>
+                    <code code="48765-2" displayName="Allergies and adverse reactions Document"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Allergies, Adverse Reactions, Alerts</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Substance</th>
+                                    <th>Reaction</th>
+                                    <th>Status</th>
+                                    <th>Criticality</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_0" xmlns="urn:hl7-org:v3"
+                                            >penicillin G </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_0_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_0_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_0" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_0" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_1" xmlns="urn:hl7-org:v3"
+                                            >ampicillin </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_1_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_1_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_1" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_1" xmlns="urn:hl7-org:v3"
+                                            >Low</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201810241352-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Canonica</family>
+                                                  <given>Gina</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="7980" displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_0"/>
+                                                  </originalText>
+                                                  <translation code="4977"
+                                                  displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>penicillin G</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_0_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_0_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_0_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101121613-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="733" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_1"/>
+                                                  </originalText>
+                                                  <translation code="2692" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>ampicillin</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_1_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_1_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_1_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="CRITL" displayName="Low"
+                                                codeSystem="2.16.840.1.113883.5.1063"
+                                                codeSystemName="HL7SeverityObservation"
+                                                xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Medications"/>
+                    <code code="10160-0" displayName="History of Medication use Narrative"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_0" xmlns="urn:hl7-org:v3"
+                                            >Aranesp 500 mcg/mL (in polysorbate) injection
+                                            syringe</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_0" xmlns="urn:hl7-org:v3">inject
+                                            1 milliliter by subcutaneous route every week</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_0" xmlns="urn:hl7-org:v3">2.25
+                                            MCG/KG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_1" xmlns="urn:hl7-org:v3"
+                                            >clindamycin 300 mg capsule</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_1" xmlns="urn:hl7-org:v3">take 1
+                                            capsule by oral route 3 times every day if pain does not
+                                            subside as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_1" xmlns="urn:hl7-org:v3">300
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-01-2017 - Oct-30-2018</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_2" xmlns="urn:hl7-org:v3"
+                                            >Tylenol Extra Strength 500 mg tablet</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_2" xmlns="urn:hl7-org:v3">take 1
+                                            tablet by oral route every 4 hours as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_2" xmlns="urn:hl7-org:v3">500
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jul-01-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_2" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_3" xmlns="urn:hl7-org:v3"
+                                            >ceftriaxone 100 gram solution for injection</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_3" xmlns="urn:hl7-org:v3">inject
+                                            10 milligram by injection route 2 times every
+                                            day</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_3" xmlns="urn:hl7-org:v3">10
+                                            milligram</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jun-30-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="5418eadb-2b53-4aa6-9875-2f918456f0fa"/>
+                            <text>
+                                <reference value="#MedicationSig_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="1" unit="wk"/>
+                            </effectiveTime>
+                            <routeCode code="C38299" displayName="SUBCUTANEOUS"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="mL"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="731241"
+                                            displayName="1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe [Aranesp]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_0"/>
+                                            </originalText>
+                                            <translation code="55513003201"
+                                                displayName="darbepoetin alfa in polysorbat"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe
+                                            [Aranesp]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706142020-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="ddd500c2-4399-4a50-addd-aa2c26fa3fdf"/>
+                            <text>
+                                <reference value="#MedicationSig_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20170901"/>
+                                <high value="20181030"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="true" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="8" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{capsule}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="748748"
+                                            displayName="clindamycin 300 MG Oral Capsule [Cleocin]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_1"/>
+                                            </originalText>
+                                            <translation code="00527138301"
+                                                displayName="clindamycin HCl"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>clindamycin 300 MG Oral Capsule [Cleocin]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170901"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201810241401-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="6936cfb5-ad96-457e-8a90-1d71fd7e71f9"/>
+                            <text>
+                                <reference value="#MedicationSig_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150701"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="4" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{tablet}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="209459"
+                                            displayName="acetaminophen 500 MG Oral Tablet [Tylenol]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_2"/>
+                                            </originalText>
+                                            <translation code="00450044406"
+                                                displayName="acetaminophen"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>acetaminophen 500 MG Oral Tablet [Tylenol]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101141402-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="f6552a8d-5ae6-42ce-a4a8-e86bcba51a7d"/>
+                            <text>
+                                <reference value="#MedicationSig_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150630"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="12" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38291" displayName="PARENTERAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="10" unit="mg"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="309090"
+                                            displayName="ceftriaxone 100 MG/ML Injectable Solution"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_3"/>
+                                            </originalText>
+                                            <translation code="66288610001"
+                                                displayName="ceftriaxone sodium"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201554-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Problems"/>
+                    <code code="11450-4" displayName="PROBLEM LIST"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Problems</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Condition</th>
+                                    <th>Type</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Clinical Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Chronic rejection of renal
+                                            transplant</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Overweight</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - Jun-01-2007</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Problem resolved
+                                            (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="dc419944-c4a3-4343-9782-7c3468b5be90"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="386661006" displayName="Fever"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202102081114-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="770ff05e-9f26-4245-a4e6-48c88b7a8a6e"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="236578006"
+                                        displayName="Chronic rejection of renal transplant"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111005"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="59621000" displayName="Essential hypertension"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111005"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems2"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="83986005" displayName="Severe hypothyroidism"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101191712-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems3"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems4"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                                <high value="20070601"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="cb229847-35f2-4d70-bc2d-b3713e82763d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high value="20070601"/>
+                                    </effectiveTime>
+                                    <value code="238131007" displayName="Overweight"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201705081255-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems4"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="413322009"
+                                                displayName="Problem resolved (finding)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+					<!-- Procedures Section -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Procedures"/>
+                    <code code="47519-4" displayName="HISTORY OF PROCEDURES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Procedures</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure</th>
+                                    <th>Universal Device Identifier/Device Identifier</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_0" xmlns="urn:hl7-org:v3"
+                                            >Nebulizer Therapy</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_1" xmlns="urn:hl7-org:v3"
+                                            >Introduction of cardiac pacemaker system via
+                                            vein</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4 -
+                                                (01)00643169007222(17)160128(21)BLC200461H</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_3" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_Procedures_0" xmlns="urn:hl7-org:v3"
+                                            >Dr Albert Davis examined Ms Alice Newman and found that
+                                            the pacemaker is operating properly and the
+                                            breathlessness is due to high fever and
+                                            anxiety.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="aaff7f65-82dc-4039-85ac-5db62a9d983e"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_0"/>
+                                </originalText>
+                                <translation code="94640" displayName="Nebulizer Therapy"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101112008-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_1"/>
+                                </originalText>
+                                <translation code="33216"
+                                    displayName="Introduction of cardiac pacemaker system via vein"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                                <high value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.37"/>
+                                    <id root="1.3.160"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="GS1"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK"/>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="1.3.160"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="ff884e65-94e1-4e11-9438-74b67d03da41"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_2"/>
+                                </originalText>
+                                <translation code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                                <high value="20200304"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041448-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="07250fe9-b4ac-485f-b42d-3dff1df1ddd8"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_3"/>
+                                </originalText>
+                                <translation code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                                <high value="20200228"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281407-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+							<!-- Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<!-- relevant identifying code 28570-0 in error -->
+                                <translation code="28570-0" displayName="Procedure note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_Procedures_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+								<!-- -dbTest 1 - update to be valid as per provenance reqs (add time-zone) (even though not provenance) -->
+                                <time value="202101251456-0500"/> <!-- this time should no longer show up in 'provenance' error (or any content error) -->
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- this time should now show up as a valid provenance error as is provenance and has no time-zone -->
+                                <time value="20210125145611"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Results"/>
+                    <code code="30954-2"
+                        displayName="Relevant diagnostic tests &amp;or laboratory data"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Results</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Test Name</th>
+                                    <th>Date and Time</th>
+                                    <th>Measure</th>
+                                    <th>Units</th>
+                                    <th>Reference Range</th>
+                                    <th>Abnormal Flag</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_0" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Urinanalysis macro (dipstick)
+                                            panel</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_0" xmlns="urn:hl7-org:v3"
+                                            >SPECIMEN: source: Urine specimen, Urine</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_0" xmlns="urn:hl7-org:v3"
+                                            >Color of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_0"
+                                            xmlns="urn:hl7-org:v3">YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_0" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_1" xmlns="urn:hl7-org:v3"
+                                            >Appearance of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_1"
+                                            xmlns="urn:hl7-org:v3">CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_1" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_2" xmlns="urn:hl7-org:v3"
+                                            >Specific gravity of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>1.015</content>
+                                    </td>
+                                    <td>
+                                        <content>1</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_2"
+                                            xmlns="urn:hl7-org:v3">1.005-1.030</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_2" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_3" xmlns="urn:hl7-org:v3"
+                                            >pH of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>5.0</content>
+                                    </td>
+                                    <td>
+                                        <content>pH</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_3"
+                                            xmlns="urn:hl7-org:v3">5.0-8.0</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_3" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_4" xmlns="urn:hl7-org:v3"
+                                            >Glucose [Mass/volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>50</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_4"
+                                            xmlns="urn:hl7-org:v3">Neg</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_4" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_5" xmlns="urn:hl7-org:v3"
+                                            >Ketones [Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_5"
+                                            xmlns="urn:hl7-org:v3">Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_5" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_6" xmlns="urn:hl7-org:v3"
+                                            >Protein[Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>100</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_6"
+                                            xmlns="urn:hl7-org:v3">negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_6" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_1" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Chest X-ray 2 views</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_1_0" xmlns="urn:hl7-org:v3"
+                                            >Chest X-ray 2 Views</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 21:54:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Abnormal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_1_0"
+                                            xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>A</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_1_0" xmlns="urn:hl7-org:v3">Lungs
+                                            are not clear, cannot rule out Anemia. Other tests are
+                                            required to determine the presence or absence of Anemia.
+                                        </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note Type</th>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Laboratory Report Narrative</content>
+                                    </td>
+                                    <td>
+                                        <content ID="clinNotes_Results_0" xmlns="urn:hl7-org:v3">Ms
+                                            Alice Newman was tested for the Urinanalysis macro panel
+                                            and the results have been found to be normal.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="f05926e4-90b4-4d39-b7db-46c5ae2c28bf"/>
+                            <code code="24357-6" displayName="Urinanalysis macro (dipstick) panel"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_0"/>
+                                </originalText>
+                                <translation code="81002"
+                                    displayName="Urinalysis, non-automated, w/scope"
+                                    codeSystemName="L"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000-0400"/>
+                                <high value="20150622110000-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622110000"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706301717-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Interface</family>
+                                            <given>Rosetta</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5778-6" displayName="Color of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">YELLOW</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>YELLOW</text>
+                                            <value xsi:type="ST">YELLOW</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5767-9" displayName="Appearance of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">CLEAR</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>CLEAR</text>
+                                            <value xsi:type="ST">CLEAR</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5811-5"
+                                        displayName="Specific gravity of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="1.015" unit="1"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>1.005-1.030</text>
+                                            <value xsi:type="ST">1.005-1.030</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5803-2" displayName="pH of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="5.0" unit="[pH]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>5.0-8.0</text>
+                                            <value xsi:type="ST">5.0-8.0</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5792-7"
+                                        displayName="Glucose [Mass/volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="50" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Neg</text>
+                                            <value xsi:type="ST">Neg</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5797-6"
+                                        displayName="Ketones [Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_5"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">Negative</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Negative</text>
+                                            <value xsi:type="ST">Negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5804-0"
+                                        displayName="Protein[Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_6"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="100" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>negative</text>
+                                            <value xsi:type="ST">negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="5f09fddb-1a80-4a65-8d24-8a2a08637f09"/>
+                            <code code="36643-5" displayName="Chest X-ray 2 views"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_1"/>
+                                </originalText>
+                                <translation code="71010" displayName="Chest X-ray"
+                                    codeSystemName="R"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622115900-0400"/>
+                                <high value="20150622115900-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622115900"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706281613-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="36643-5" displayName="Chest X-ray 2 Views"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_1_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622215400-0400"/>
+                                    <value xsi:type="ST">Abnormal</value>
+                                    <interpretationCode code="A" displayName="Abnormal"
+                                        codeSystem="2.16.840.1.113883.5.83"
+                                        codeSystemName="HL7 Observation Interpretation"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622115900"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706281613-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>User</family>
+                                                  <given>Adam</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                            <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ResultComment_1_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                        </act>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#clinNotes_Results_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20210125145624"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="AdvanceDirectives"/>
+                    <code code="42348-3" displayName="ADVANCE DIRECTIVES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Advance Directives</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Directive</th>
+                                    <th>Yes / No</th>
+                                    <th>Effective Date</th>
+                                    <th>File Name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownAdvanceDirective" xmlns="urn:hl7-org:v3"
+                                            >No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Encounters"/>
+                    <code code="46240-8" displayName="HISTORY OF ENCOUNTERS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Encounters</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Description</th>
+                                    <th>Practice</th>
+                                    <th>Location</th>
+                                    <th>Reason(s) For Visit</th>
+                                    <th>Diagnoses</th>
+                                    <th>Date</th>
+                                    <th>Provider</th>
+                                    <th>Providers Copied on Encounter</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                    <td>
+                                        <content>HoitzThisIsAReallyLongLa TerryThisIsAReallyLongFi.
+                                            1 Jarrett White Rd, Tripler Army Medical Center, HI,
+                                            968595000, US. tel:+1-8084331212</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_1" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>
+                                                <content>sore throat (chief complaint)</content>
+                                            </item>
+                                            <item>
+                                                <content>Sore throat (chief complaint)</content>
+                                            </item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Acute tonsillitis due to other specified
+                                                organisms</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension (chief complaint)</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Hypertension</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Fever - Finding</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="9d7d931c-948f-4a59-a532-d9b96c868129"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_0"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202109201436"/>
+                                <high value="202109201436"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                                        <city>Tripler Army Medical Center</city>
+                                        <state>HI</state>
+                                        <postalCode>96859-5000</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-8084331212"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>HoitzThisIsAReallyLongLa</family>
+                                            <given>TerryThisIsAReallyLongFi</given>
+                                            <given>TerrysMiddleName-35-</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id nullFlavor="UNK"/>
+                                            <code nullFlavor="UNK">
+                                                <translation nullFlavor="UNK"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"/>
+                            <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_1"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202003041348"/>
+                                <high value="202003041348"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200304"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_1"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="285533fa-4983-4e30-b718-c2942646ea36"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="J03.80"
+                                                displayName="Acute tonsillitis due to other specified organisms"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time nullFlavor="UNK"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202003041440-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="26db8415-1153-455c-a328-da1aeb35e30f"/>
+                            <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_2"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202002281351"/>
+                                <high value="202002281351"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200228"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_2"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="5ad6f921-233e-4d8c-927d-ecfd26bfbaf9"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20200228"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="I10" displayName="Hypertension"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20200228"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202002281406-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_3"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="201506221000"/>
+                                <high value="201506221000"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                            <code code="~" displayName="~"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation nullFlavor="NA"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20150622"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="R50.9" displayName="Fever - Finding"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20150622"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202103261221-0400"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom value="5555551002"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FamilyHistory"/>
+                    <code code="10157-6" displayName="HISTORY OF FAMILY MEMBER DISEASES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Family History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Family Member</th>
+                                    <th>Type</th>
+                                    <th>Diagnosis</th>
+                                    <th>Age At Onset</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_0"
+                                            xmlns="urn:hl7-org:v3">Alive and well</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_1"
+                                            xmlns="urn:hl7-org:v3">Family history of
+                                            asthma</content>
+                                    </td>
+                                    <td>
+                                        <content>16</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"
+                                extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <statusCode code="completed"/>
+                            <subject>
+                                <relatedSubject classCode="PRS">
+                                    <code code="BRO" displayName="Brother"
+                                        codeSystem="2.16.840.1.113883.5.111"
+                                        codeSystemName="HL7RoleCode"/>
+                                    <subject>
+                                        <sdtc:id root="1.3.6.1.4.1.21367.13.40.117"
+                                            extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"
+                                            xmlns:sdtc="urn:hl7-org:sdtc"/>
+                                        <name>Kenneth</name>
+                                        <administrativeGenderCode code="M" displayName="Male"
+                                            codeSystem="2.16.840.1.113883.5.1"
+                                            codeSystemName="HL7AdministrativeGender"/>
+                                        <birthTime nullFlavor="UNK"/>
+                                    </subject>
+                                </relatedSubject>
+                            </subject>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160445003" displayName="Alive and well"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_0"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="d1af37b2-178e-4cd9-ae47-3f63d9d6947f"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160377001" displayName="Family history of asthma"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_1"/>
+                                        </originalText>
+                                    </value>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.31"/>
+                                            <code code="445518008" displayName="Age At Onset"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT"/>
+                                            <statusCode code="completed"/>
+                                            <value value="16" unit="a" xsi:type="PQ"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Immunizations"/>
+                    <code code="11369-6" displayName="HISTORY OF IMMUNIZATION NARRATIVE"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Immunizations</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Vaccine</th>
+                                    <th>Date</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_0" xmlns="urn:hl7-org:v3"
+                                            >influenza, intradermal, quadrivalent, preservative
+                                            free, injectable</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>refused</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_0" xmlns="urn:hl7-org:v3"
+                                            >Note: Immunization was not given - Patient rejected
+                                            immunization. ; Source: New Immunization Record
+                                        </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_1" xmlns="urn:hl7-org:v3"
+                                            >diphtheria, tetanus toxoids and acellular pertussis
+                                            vaccine, 5 pertussis antigens</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-04-2012</content>
+                                    </td>
+                                    <td>
+                                        <content>administered</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_1" xmlns="urn:hl7-org:v3"
+                                            >Source: Source Unspecified </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="true">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="51f02998-93bb-4385-9050-873373b9fc44"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_0"/>
+                            </text>
+                            <statusCode code="aborted"/>
+                            <effectiveTime value="20150622"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="166"
+                                            displayName="influenza, intradermal, quadrivalent, preservative free, injectable"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_0"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK"/>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319185347"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706151004-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="ba7049e4-8bcb-4a44-84e8-9e3f40d28f5f"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20120104"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="106"
+                                            displayName="diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_1"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText>2</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319184655"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201705081257-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Payer"/>
+                    <code code="48768-6" displayName="PAYMENT SOURCES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Payers</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Payer name</th>
+                                    <th>Insurance type</th>
+                                    <th>Covered party ID</th>
+                                    <th>Authorization(s)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownPayer" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="SocialHistory"/>
+                    <code code="29762-2" displayName="SOCIAL HISTORY"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Social History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Description</th>
+                                    <th>Quantity</th>
+                                    <th>Date Captured</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_0" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_0"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_0"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_1" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_1"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_1"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_2" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Cigarette smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_2"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_3" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Current every day smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_3"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobacco_5"
+                                            xmlns="urn:hl7-org:v3">Smoking Tobacco Use
+                                            Details</content>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobaccoDate_5"
+                                            xmlns="urn:hl7-org:v3">Aug-17-2017</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_6" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_6"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_6"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_7" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_7"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_7"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_8" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_8"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_9" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_9"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_11" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_11"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_11"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_12"
+                                            xmlns="urn:hl7-org:v3">Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_12"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_12"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_13" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_13"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_14" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_14"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Birth Sex</content>
+                                    </td>
+                                    <td>
+                                        <content ID="BSex_value0" xmlns="urn:hl7-org:v3"
+                                            >Female</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_3"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20150622"/>
+                            <value code="449868002" displayName="Current every day smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_9"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200304"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_14"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200228"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_0"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_6"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_11"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe" extension="TobaccoUse"/>
+                            <code code="11367-0" displayName="History of tobacco use"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistoryTobacco_2"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value code="65568007" displayName="Cigarette smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_1"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_7"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_12"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="SmokingTobacco"/>
+                            <code code="229819007" displayName="Tobacco use and exposure"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistorySmokingTobacco_5"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20170817"/>
+                            </effectiveTime>
+                            <value xsi:type="ST">Cigarette: No Details Available Quantity Details -
+                                Cigarette: No Details Available </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708170737-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.200"
+                                extension="2016-06-01"/>
+                            <code code="76689-9" displayName="Sex Assigned At Birth"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#BSex_value0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1"
+                                codeSystemName="HL7AdministrativeGender" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BSex_value0"/>
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202104020755-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="VitalSigns"/>
+                    <code code="8716-3" displayName="VITAL SIGNS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Vital Signs</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date / Time:</th>
+                                    <th>Height</th>
+                                    <th>Weight</th>
+                                    <th>BMI</th>
+                                    <th>Pulse Rate</th>
+                                    <th>Blood Pressure</th>
+                                    <th>Temperature</th>
+                                    <th>Respiratory Rate</th>
+                                    <th>Body Surface Area</th>
+                                    <th>Head Circumference</th>
+                                    <th>Head Circ. Percentile</th>
+                                    <th>Wt./Len. Percentile</th>
+                                    <th>BMI percentile</th>
+                                    <th>Pulse Ox</th>
+                                    <th>Inhaled Ox</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015 10:05 AM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_0" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_0" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_0" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeartBeat_0" xmlns="urn:hl7-org:v3"
+                                            >80 /min</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_0"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_0" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsRespiratoryRate_0"
+                                            xmlns="urn:hl7-org:v3">18 /min</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsPulseOx_0" xmlns="urn:hl7-org:v3">95
+                                            %</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsInhaledOxyConc_0"
+                                            xmlns="urn:hl7-org:v3">36 %</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020 1:55 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_1" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_1" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_1" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_1"
+                                            xmlns="urn:hl7-org:v3">150/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_1" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020 1:59 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_2" xmlns="urn:hl7-org:v3"
+                                            >65.00 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_2" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (165.00 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_2" xmlns="urn:hl7-org:v3">27.46
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_2"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="201506221005-0400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201707271030-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_height_0"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_weight_0"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_systolic_0"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_diastolic_0"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="heart_rate_0"/>
+                                    <code code="8867-4" displayName="Heart Rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeartBeat_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="80" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_temperature_0"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="respiratory_rate_0"/>
+                                    <code code="9279-1" displayName="Respiratory rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsRespiratoryRate_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="18" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="sao2_%_blda_pulseox_0"/>
+                                    <code code="59408-5" displayName="SaO2 % BldA PulseOx"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsPulseOx_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="95" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="inhaled_oxygen_concentration_0"/>
+                                    <code code="3150-0" displayName="Inhaled Oxygen Concentration"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsInhaledOxyConc_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="36" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202003041355-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200304"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111850-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_height_1"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_weight_1"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_systolic_1"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="150" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_diastolic_1"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_temperature_1"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_mass_index_1"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202002281359-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174" extension="43"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281401-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_height_2"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_weight_2"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_systolic_2"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_diastolic_2"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_mass_index_2"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="27.46" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="ChiefComplaintAndReasonForVisit"/>
+                    <code code="46239-0" displayName="CHIEF COMPLAINT AND REASON FOR VISIT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Chief Complaint And Reason For Visit</title>
+                    <text>
+                        <paragraph>No Information</paragraph>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ReferralReason"/>
+                    <code code="42349-1" displayName="REASON FOR REFERRAL"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Reason For Referral</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Reason For Referral</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="1">
+                                        <content ID="UnknownReferral" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="PlanOfCare"/>
+                    <code code="18776-5" displayName="TREATMENT PLAN"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Plan Of Treatment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Action</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Radiology Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_0" xmlns="urn:hl7-org:v3">EKG
+                                            (93000), Scheduled for: Jun-23-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Lab Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_1" xmlns="urn:hl7-org:v3"
+                                            >Urinanalysis macro (dipstick) panel (81002), Scheduled
+                                            for: Jun-29-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="bdb795ab-6f6d-415e-956c-fb87940dd574"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#FutureOrder_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506230400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708151638-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="3f143484-5a7b-4aca-acab-1bf2f8539896"/>
+                            <code code="24357-6"
+                                displayName="Urinalysis macro (dipstick) panel - Urine"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#FutureOrder_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506291200"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201725-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HistoryOfPresentIllness"/>
+                    <code code="10164-2" displayName="HISTORY OF PRESENT ILLNESS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History Of Present Illness</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Date</th>
+                                    <th>Complaint</th>
+                                    <th>History Of Present Illness</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>The HTN started in 2015. The symptoms began
+                                            gradually. The severity has been described as being 6.
+                                            It is currently stable. Risk factors include inactive
+                                            lifestyle, obesity, sleep apnea and smoking. The
+                                            hypertension is exacerbated by anxiety. Associated
+                                            symptoms include fatigue and headache.</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FunctionalStatus"/>
+                    <code code="47420-5" displayName="Functional Status"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Functional Status</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Functional Assessment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>May-01-2005</content>
+                                    </td>
+                                    <td>
+                                        <content>Dependence on cane</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"
+                                extension="2014-06-09"/>
+                            <id nullFlavor="UNK"/>
+                            <code nullFlavor="NP"/>
+                            <statusCode code="completed"/>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"
+                                        extension="2014-06-09"/>
+                                    <id root="e942984a-f2fb-416e-80ce-d481c8b0fb71"/>
+                                    <code code="54522-8" displayName="Functional Status"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20050501"/>
+                                    <value code="105504002" displayName="Dependence on cane"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.128"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime nullFlavor="UNK"/>
+                                    <value nullFlavor="UNK" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CcdaMedicationsAdministered"/>
+                    <code code="29549-3" displayName="MEDICATION ADMINISTERED"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications Administered</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="UnknownMedicationAdministered"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Instructions"/>
+                    <code code="69730-0" displayName="INSTRUCTIONS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Instructions</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Instruction</th>
+                                    <th>Additional Information</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PatientInstruction_0" xmlns="urn:hl7-org:v3">i.
+                                            Get an EKG done on 6/23/2015. ii. Get a Chest X-ray done
+                                            on 6/23/2015 showing the Lower Respiratory Tract
+                                            Structure. iii. Take Clindamycin 300mg three times a day
+                                            as needed if pain does not subside. iv. Schedule follow
+                                            on visit with Neighborhood Physicians Practice on
+                                            7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Related to Fever - Finding</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act moodCode="INT" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="1d98f86c-5319-45d4-98fa-a26df91591dc"/>
+                            <code code="423564006" displayName="Provider Instructions for treatment"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+                            <text>
+                                <reference value="#PatientInstruction_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000"/>
+                            </effectiveTime>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Assessment"/>
+                    <code code="51848-0" displayName="ASSESSMENTS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Assessments</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Assessment</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Fever - Finding</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>impression</content>
+                                    </td>
+                                    <td>
+                                        <content>The patient was found to have fever and Dr Davis is
+                                            suspecting Anemia based on the patient history. So Dr
+                                            Davis asked the patient to closely monitor the
+                                            temperature and blood pressure and get admitted to
+                                            Community Health Hospitals if the fever does not subside
+                                            within a day. i. Get an EKG done on 6/23/2015. ii. Take
+                                            Clindamycin 300mg three times a day as needed if pain
+                                            does not subside. iii. Schedule follow on visit with
+                                            Neighborhood Physicians Practice on 7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Acute tonsillitis due to other specified
+                                            organisms</content>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.60"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Goals"/>
+                    <code code="61146-7" displayName="GOALS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Goals</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Goal</th>
+                                    <th>Type</th>
+                                    <th>Priority</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Fever</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_0" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occurring every few
+                                            weeks.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_1" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_2" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occuring every few
+                                            weeks</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_3" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="3b72c7a7-2b83-4e68-a1c9-bcc637fd389f"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occurring
+                                every few weeks.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="d2b8277e-2016-4489-b2db-34360fde0cd0"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="eff3999e-ad61-477c-864f-402b281924a3"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occuring
+                                every few weeks</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="41ccf5d4-05af-48f1-949d-659040b8a781"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="MedicalEquipment"/>
+                    <code code="46264-8" displayName="MEDICAL EQUIPMENT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medical Equipment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th>Device</th>
+                                    <th>Universal Device Identifier</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Device Status</th>
+                                    <th>Implantable Device Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ImplantableProcDev__0_0" xmlns="urn:hl7-org:v3"
+                                            >CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>(01)00643169007222(17)160128(21)BLC200461H</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.313"
+                                extension="2018-05-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code code="33216"
+                                displayName="Introduction of cardiac pacemaker system via vein"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"
+                                xsi:type="CE"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.310"
+                                        extension="2018-05-01"/>
+                                    <id root="2.16.840.1.113883.3.3719"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="FDA"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK">
+                                            <originalText>
+                                                <reference value="#ImplantableProcDev__0_0"/>
+                                            </originalText>
+                                        </code>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="2.16.840.1.113883.3.3719"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP">
+                                <organizer classCode="CLUSTER" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.311"
+                                        extension="2019-06-21"/>
+                                    <id extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        root="2.16.840.1.113883.3.3719"/>
+                                    <code code="74711-3" displayName="Unique Device Identifier"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.304"
+                                                extension="2019-06-21"/>
+                                            <code code="C101722" displayName="Primary DI Number"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value root="1.3.160" extension="00643169007222"
+                                                displayable="true" assigningAuthorityName="GS1"
+                                                xsi:type="II"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.318"
+                                                extension="2019-06-21"/>
+                                            <code code="C106044" displayName="MRI Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C113844"
+                                                displayName="Labeling does not contain MRI Safety Information"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.46"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.314"
+                                                extension="2019-06-21"/>
+                                            <code code="C160938" displayName="Latex Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C106038"
+                                                displayName="Not Made with Natural Rubber Latex"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.47"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.305"
+                                                extension="2019-06-21"/>
+                                            <code code="C160939"
+                                                displayName="Implantable Device Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C45329" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.48"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.306"
+                                                extension="2018-05-01"/>
+                                            <code code="UDI-00007" displayName="Device Status"
+                                                codeSystem="1.3.6.1.4.1.19376.1.4.1.6.5.290"
+                                                codeSystemName="UDI Observation Type"/>
+                                            <value code="active"
+                                                codeSystem="2.16.840.1.113883.4.642.3.199"
+                                                codeSystemName="Device Status" xsi:type="CD"/>
+                                        </observation>
+                                    </component>
+                                </organizer>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HealthConcerns"/>
+                    <code code="75310-3" displayName="HEALTH CONCERNS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Observation</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthStatusObs_0" xmlns="urn:hl7-org:v3"
+                                            >Chronically ill</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Concern</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_0" xmlns="urn:hl7-org:v3"
+                                            >Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_1" xmlns="urn:hl7-org:v3"
+                                            >Weight - 88.000 kg</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_2" xmlns="urn:hl7-org:v3"
+                                            >Fever - Finding - R50.9</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_3" xmlns="urn:hl7-org:v3">BMI
+                                            - 28.08 - Watch weight of patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_4" xmlns="urn:hl7-org:v3"
+                                            >Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_5" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_6" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_7" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_8" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="EVN" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5" extension="2014-06-09"/>
+                            <id root="45cf87bf-0952-4e7c-b049-ad19b435729e"/>
+                            <code code="11323-3" displayName="HEALTH STATUS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthStatusObs_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="161901003" displayName="Chronically ill"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111912-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c7dcddd1-8a45-4536-8975-9df72a77d474"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6c1d5761-3b89-4592-97ac-67905ef3e3d8"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="a30988e2-aab4-4ff7-8ac8-a286393f22fb"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061059-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_4"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061100-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="5214ea51-a323-4a9e-860d-7b8f688688cd"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_5"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="deda0b49-2996-411b-b9b9-e517db9bec04"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_6"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061057-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c5bb9c90-1562-42b4-a2c1-fcf7868443e5"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_7"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_8"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061058-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.500" extension="2019-07-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CareTeam"/>
+                    <code code="85847-2" displayName="PATIENT CARE TEAM"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Patient Care Teams</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Members</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_0" xmlns="urn:hl7-org:v3">Core
+                                            Team</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>nullified</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item> Kristin Allison.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_1" xmlns="urn:hl7-org:v3">Care Team
+                                            A</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>[Family medicine specialist] Albert Davis, 2472
+                                                Rocky Place, Beaverton, OR, 97006.</item>
+                                            <item>[grandfather] Rick Holler, 1357 Amber Dr,
+                                                Beaverton, OR, 97006.</item>
+                                            <item>[spouse] Matthew Newman, 1357 Amber Dr.,
+                                                Beaverton, OR, 97006.</item>
+                                            <item> Tracy Davis, 2472 Rocky Place, Beaverton, OR,
+                                                97006.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="5ae3655e-dfe0-4bf9-9ec3-b3693d6956f5"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_0"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="nullified"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101291121-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="9a7b1756-d0a6-4db9-93f9-260dbaa04dc7"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode nullFlavor="UNK"/>
+                                    <effectiveTime>
+                                        <low nullFlavor="UNK"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low nullFlavor="UNK"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id root="2.16.840.1.113883.4.6" extension="1528951720"/>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Allison</family>
+                                                  <given>Kristin</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="1755af9d-4c9f-4442-ac10-fc9d2b264338"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_1"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101191649-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="6ebb65ef-0d6f-4358-87da-96e4b71f8b4b"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="207Q00000X"
+                                                displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Neighborhood Physicians Practice</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="48563921-dded-4fc5-b54e-0b86775d7fca"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Holler</family>
+                                                  <given>Rick</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="335b6602-a8b2-4d3d-8744-9ad850e7ebc6"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Newman</family>
+                                                  <given>Matthew</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="b72378a1-6e51-4e33-a209-93374a095f12"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="251B00000X"
+                                                displayName="Agencies : Case Management"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Tracy</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="DischargeSummaryClinicalNotes"/>
+                    <code code="18842-5" displayName="Discharge summary"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Discharge Summary Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownDischargeSummaryClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="18842-5" displayName="Discharge summary"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownDischargeSummaryClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ConsultNoteClinicalNotes"/>
+                    <code code="11488-4" displayName="Consult Note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Consultation Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownConsultNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11488-4" displayName="Consult Note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownConsultNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="HistoryPhysicalNoteClinicalNotes"/>
+                    <code code="34117-2" displayName="History and physical note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History and Physical Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownHistoryPhysicalNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="34117-2" displayName="History and physical note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownHistoryPhysicalNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ProgressNoteNoteClinicalNotes"/>
+                    <code code="11506-3" displayName="Progress note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Progress Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_ProgressNoteNoteClinicalNotes_0"
+                                            xmlns="urn:hl7-org:v3">Ms Alice Newman seems to be
+                                            developing high fever and hence we recommend her to get
+                                            admitted to a nearby hospital using the provided
+                                            referral. </content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                        	<!--  Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11506-3" displayName="Progress note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_ProgressNoteNoteClinicalNotes_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210920"/>
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 valid TS as per provenance reqs, but is not provenance, so irrelevant, no error expected
+                                 -->
+                                <time value="202109201442-0400"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="9d7d931c-948f-4a59-a532-d9b96c868129"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331.xml
+++ b/src/test/resources/cures/sub/SUB_INVALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SWAP_AUTHORS_SITE_3331.xml
@@ -1,0 +1,10364 @@
+<?xml version="1.0"?><?xml-stylesheet type='text/xsl' href='http://www.nextgenshare.com/public/CDA_NGMU2.xsl'?>
+<ClinicalDocument xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc"
+    xmlns="urn:hl7-org:v3" xmlns:mif="urn:hl7-org:v3/mif"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US"/>
+    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+    <id root="1.3.6.1.4.1.21367.13.40.117" extension="f0b0de8a-dfd1-458b-99a5-523011eba40b"/>
+    <code code="34133-9" displayName="SUMMARIZATION OF EPISODE NOTE"
+        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+    <title>Continuity of Care Document (C-CDA R2.1)</title>
+    <effectiveTime value="20210920164540-0400"/>
+    <confidentialityCode code="N" displayName="Normal Sharing" codeSystem="2.16.840.1.113883.5.25"
+        codeSystemName="HL7 Confidentiality"/>
+    <languageCode code="en-US"/>
+    <recordTarget>
+        <patientRole>
+            <id extension="8658" root="1.100"/>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom use="MC" value="tel:+1-5557771234"/>
+            <telecom use="HP" value="tel:+1-5557231544"/>
+            <telecom value="mailto:sadavis@nextgen.com"/>
+            <patient>
+                <name use="L">
+                    <family>Newman</family>
+                    <given qualifier="CL">Alice</given>
+                    <given>Jones</given>
+                </name>
+                <name use="SRCH">
+                    <family>Newman</family>
+                    <given qualifier="BR">Alicia</given>
+                </name>
+                <administrativeGenderCode code="F" displayName="Female"
+                    codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
+                <birthTime value="19700501"/>
+                <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicitys"/>
+                <sdtc:raceCode code="2108-9" displayName="European"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+                <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicitys"/>
+                <languageCommunication>
+                    <templateId root="2.16.840.1.113883.3.88.11.32.2"/>
+                    <languageCode code="en"/>
+                    <preferenceInd value="true"/>
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id root="1.174" extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+        </assignedAuthor>
+    </author>
+    <author>
+        <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id nullFlavor="UNK"/>
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom value="5555551002"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom value="5555551002"/>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <informant>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Admin</family>
+                    <given>NEXTGEN</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </informant>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <legalAuthenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom use="WP" nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </legalAuthenticator>
+    <authenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </authenticator>
+    <participant typeCode="IND">
+        <time value="19400101"/>
+        <associatedEntity classCode="PRS">
+            <code code="GRPRN" displayName="grandparent" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="04" displayName="Grandparent"
+                    codeSystem="2.16.840.1.113883.3.109" codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Holler</family>
+                    <given>Rick</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <time value="19790101"/>
+        <associatedEntity classCode="PRS">
+            <code code="SPS" displayName="spouse" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="01" displayName="Spouse" codeSystem="2.16.840.1.113883.3.109"
+                    codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Newman</family>
+                    <given>Matthew</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <associatedEntity classCode="CAREGIVER">
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+            </addr>
+            <telecom use="HP" value="tel:+1-5555551002"/>
+            <associatedPerson>
+                <name>
+                    <family>Allison</family>
+                    <given>Kristin</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <functionCode code="PCP" codeSystem="2.16.840.1.113883.5.88"/>
+        <associatedEntity classCode="CAREGIVER">
+            <associatedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <documentationOf typeCode="DOC">
+        <serviceEvent classCode="PCPR">
+            <effectiveTime>
+                <low value="201506221000"/>
+                <high value="202109201436"/>
+            </effectiveTime>
+            <performer typeCode="PRF">
+                <time>
+                    <low value="202109201645"/>
+                    <high value="202109201645"/>
+                </time>
+                <assignedEntity>
+                    <id root="1.174" extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"/>
+                    <addr>
+                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                        <city>Tripler Army Medical Center</city>
+                        <state>HI</state>
+                        <postalCode>96859-5000</postalCode>
+                        <country>US</country>
+                    </addr>
+                    <telecom nullFlavor="UNK"/>
+                    <assignedPerson>
+                        <name>
+                            <given>TerryThisIsAReallyLongFi</given>
+                            <family>HoitzThisIsAReallyLongLa</family>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </performer>
+        </serviceEvent>
+    </documentationOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Alerts"/>
+                    <code code="48765-2" displayName="Allergies and adverse reactions Document"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Allergies, Adverse Reactions, Alerts</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Substance</th>
+                                    <th>Reaction</th>
+                                    <th>Status</th>
+                                    <th>Criticality</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_0" xmlns="urn:hl7-org:v3"
+                                            >penicillin G </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_0_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_0_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_0" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_0" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_1" xmlns="urn:hl7-org:v3"
+                                            >ampicillin </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_1_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_1_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_1" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_1" xmlns="urn:hl7-org:v3"
+                                            >Low</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201810241352-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Canonica</family>
+                                                  <given>Gina</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="7980" displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_0"/>
+                                                  </originalText>
+                                                  <translation code="4977"
+                                                  displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>penicillin G</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_0_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_0_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_0_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101121613-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="733" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_1"/>
+                                                  </originalText>
+                                                  <translation code="2692" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>ampicillin</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_1_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_1_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_1_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="CRITL" displayName="Low"
+                                                codeSystem="2.16.840.1.113883.5.1063"
+                                                codeSystemName="HL7SeverityObservation"
+                                                xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Medications"/>
+                    <code code="10160-0" displayName="History of Medication use Narrative"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_0" xmlns="urn:hl7-org:v3"
+                                            >Aranesp 500 mcg/mL (in polysorbate) injection
+                                            syringe</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_0" xmlns="urn:hl7-org:v3">inject
+                                            1 milliliter by subcutaneous route every week</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_0" xmlns="urn:hl7-org:v3">2.25
+                                            MCG/KG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_1" xmlns="urn:hl7-org:v3"
+                                            >clindamycin 300 mg capsule</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_1" xmlns="urn:hl7-org:v3">take 1
+                                            capsule by oral route 3 times every day if pain does not
+                                            subside as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_1" xmlns="urn:hl7-org:v3">300
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-01-2017 - Oct-30-2018</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_2" xmlns="urn:hl7-org:v3"
+                                            >Tylenol Extra Strength 500 mg tablet</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_2" xmlns="urn:hl7-org:v3">take 1
+                                            tablet by oral route every 4 hours as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_2" xmlns="urn:hl7-org:v3">500
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jul-01-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_2" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_3" xmlns="urn:hl7-org:v3"
+                                            >ceftriaxone 100 gram solution for injection</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_3" xmlns="urn:hl7-org:v3">inject
+                                            10 milligram by injection route 2 times every
+                                            day</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_3" xmlns="urn:hl7-org:v3">10
+                                            milligram</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jun-30-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="5418eadb-2b53-4aa6-9875-2f918456f0fa"/>
+                            <text>
+                                <reference value="#MedicationSig_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="1" unit="wk"/>
+                            </effectiveTime>
+                            <routeCode code="C38299" displayName="SUBCUTANEOUS"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="mL"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="731241"
+                                            displayName="1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe [Aranesp]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_0"/>
+                                            </originalText>
+                                            <translation code="55513003201"
+                                                displayName="darbepoetin alfa in polysorbat"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe
+                                            [Aranesp]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706142020-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="ddd500c2-4399-4a50-addd-aa2c26fa3fdf"/>
+                            <text>
+                                <reference value="#MedicationSig_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20170901"/>
+                                <high value="20181030"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="true" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="8" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{capsule}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="748748"
+                                            displayName="clindamycin 300 MG Oral Capsule [Cleocin]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_1"/>
+                                            </originalText>
+                                            <translation code="00527138301"
+                                                displayName="clindamycin HCl"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>clindamycin 300 MG Oral Capsule [Cleocin]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170901"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201810241401-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="6936cfb5-ad96-457e-8a90-1d71fd7e71f9"/>
+                            <text>
+                                <reference value="#MedicationSig_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150701"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="4" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{tablet}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="209459"
+                                            displayName="acetaminophen 500 MG Oral Tablet [Tylenol]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_2"/>
+                                            </originalText>
+                                            <translation code="00450044406"
+                                                displayName="acetaminophen"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>acetaminophen 500 MG Oral Tablet [Tylenol]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101141402-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="f6552a8d-5ae6-42ce-a4a8-e86bcba51a7d"/>
+                            <text>
+                                <reference value="#MedicationSig_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150630"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="12" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38291" displayName="PARENTERAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="10" unit="mg"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="309090"
+                                            displayName="ceftriaxone 100 MG/ML Injectable Solution"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_3"/>
+                                            </originalText>
+                                            <translation code="66288610001"
+                                                displayName="ceftriaxone sodium"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201554-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Problems"/>
+                    <code code="11450-4" displayName="PROBLEM LIST"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Problems</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Condition</th>
+                                    <th>Type</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Clinical Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Chronic rejection of renal
+                                            transplant</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Overweight</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - Jun-01-2007</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Problem resolved
+                                            (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="dc419944-c4a3-4343-9782-7c3468b5be90"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="386661006" displayName="Fever"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202102081114-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="770ff05e-9f26-4245-a4e6-48c88b7a8a6e"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="236578006"
+                                        displayName="Chronic rejection of renal transplant"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111005"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="59621000" displayName="Essential hypertension"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111005"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems2"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="83986005" displayName="Severe hypothyroidism"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101191712-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems3"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems4"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                                <high value="20070601"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="cb229847-35f2-4d70-bc2d-b3713e82763d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high value="20070601"/>
+                                    </effectiveTime>
+                                    <value code="238131007" displayName="Overweight"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201705081255-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems4"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="413322009"
+                                                displayName="Problem resolved (finding)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+					<!-- Procedures Section -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Procedures"/>
+                    <code code="47519-4" displayName="HISTORY OF PROCEDURES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Procedures</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure</th>
+                                    <th>Universal Device Identifier/Device Identifier</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_0" xmlns="urn:hl7-org:v3"
+                                            >Nebulizer Therapy</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_1" xmlns="urn:hl7-org:v3"
+                                            >Introduction of cardiac pacemaker system via
+                                            vein</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4 -
+                                                (01)00643169007222(17)160128(21)BLC200461H</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_3" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_Procedures_0" xmlns="urn:hl7-org:v3"
+                                            >Dr Albert Davis examined Ms Alice Newman and found that
+                                            the pacemaker is operating properly and the
+                                            breathlessness is due to high fever and
+                                            anxiety.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="aaff7f65-82dc-4039-85ac-5db62a9d983e"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_0"/>
+                                </originalText>
+                                <translation code="94640" displayName="Nebulizer Therapy"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101112008-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_1"/>
+                                </originalText>
+                                <translation code="33216"
+                                    displayName="Introduction of cardiac pacemaker system via vein"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                                <high value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.37"/>
+                                    <id root="1.3.160"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="GS1"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK"/>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="1.3.160"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="ff884e65-94e1-4e11-9438-74b67d03da41"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_2"/>
+                                </originalText>
+                                <translation code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                                <high value="20200304"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041448-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="07250fe9-b4ac-485f-b42d-3dff1df1ddd8"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_3"/>
+                                </originalText>
+                                <translation code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                                <high value="20200228"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281407-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+							<!-- Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<!-- relevant identifying code 28570-0 in error -->
+                                <translation code="28570-0" displayName="Procedure note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_Procedures_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+							<!--  swapped authors -->
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- this time should now show up as a valid provenance error as is provenance and has no time-zone -->
+                                <time value="20210125145611"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+								<!-- -dbTest 1 - update to be valid as per provenance reqs (add time-zone) (even though not provenance) -->
+                                <time value="202101251456-0500"/> <!-- this time should no longer show up in 'provenance' error (or any content error) -->
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>                            
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Results"/>
+                    <code code="30954-2"
+                        displayName="Relevant diagnostic tests &amp;or laboratory data"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Results</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Test Name</th>
+                                    <th>Date and Time</th>
+                                    <th>Measure</th>
+                                    <th>Units</th>
+                                    <th>Reference Range</th>
+                                    <th>Abnormal Flag</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_0" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Urinanalysis macro (dipstick)
+                                            panel</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_0" xmlns="urn:hl7-org:v3"
+                                            >SPECIMEN: source: Urine specimen, Urine</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_0" xmlns="urn:hl7-org:v3"
+                                            >Color of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_0"
+                                            xmlns="urn:hl7-org:v3">YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_0" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_1" xmlns="urn:hl7-org:v3"
+                                            >Appearance of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_1"
+                                            xmlns="urn:hl7-org:v3">CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_1" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_2" xmlns="urn:hl7-org:v3"
+                                            >Specific gravity of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>1.015</content>
+                                    </td>
+                                    <td>
+                                        <content>1</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_2"
+                                            xmlns="urn:hl7-org:v3">1.005-1.030</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_2" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_3" xmlns="urn:hl7-org:v3"
+                                            >pH of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>5.0</content>
+                                    </td>
+                                    <td>
+                                        <content>pH</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_3"
+                                            xmlns="urn:hl7-org:v3">5.0-8.0</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_3" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_4" xmlns="urn:hl7-org:v3"
+                                            >Glucose [Mass/volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>50</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_4"
+                                            xmlns="urn:hl7-org:v3">Neg</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_4" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_5" xmlns="urn:hl7-org:v3"
+                                            >Ketones [Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_5"
+                                            xmlns="urn:hl7-org:v3">Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_5" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_6" xmlns="urn:hl7-org:v3"
+                                            >Protein[Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>100</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_6"
+                                            xmlns="urn:hl7-org:v3">negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_6" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_1" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Chest X-ray 2 views</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_1_0" xmlns="urn:hl7-org:v3"
+                                            >Chest X-ray 2 Views</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 21:54:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Abnormal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_1_0"
+                                            xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>A</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_1_0" xmlns="urn:hl7-org:v3">Lungs
+                                            are not clear, cannot rule out Anemia. Other tests are
+                                            required to determine the presence or absence of Anemia.
+                                        </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note Type</th>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Laboratory Report Narrative</content>
+                                    </td>
+                                    <td>
+                                        <content ID="clinNotes_Results_0" xmlns="urn:hl7-org:v3">Ms
+                                            Alice Newman was tested for the Urinanalysis macro panel
+                                            and the results have been found to be normal.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="f05926e4-90b4-4d39-b7db-46c5ae2c28bf"/>
+                            <code code="24357-6" displayName="Urinanalysis macro (dipstick) panel"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_0"/>
+                                </originalText>
+                                <translation code="81002"
+                                    displayName="Urinalysis, non-automated, w/scope"
+                                    codeSystemName="L"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000-0400"/>
+                                <high value="20150622110000-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622110000"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706301717-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Interface</family>
+                                            <given>Rosetta</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5778-6" displayName="Color of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">YELLOW</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>YELLOW</text>
+                                            <value xsi:type="ST">YELLOW</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5767-9" displayName="Appearance of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">CLEAR</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>CLEAR</text>
+                                            <value xsi:type="ST">CLEAR</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5811-5"
+                                        displayName="Specific gravity of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="1.015" unit="1"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>1.005-1.030</text>
+                                            <value xsi:type="ST">1.005-1.030</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5803-2" displayName="pH of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="5.0" unit="[pH]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>5.0-8.0</text>
+                                            <value xsi:type="ST">5.0-8.0</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5792-7"
+                                        displayName="Glucose [Mass/volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="50" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Neg</text>
+                                            <value xsi:type="ST">Neg</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5797-6"
+                                        displayName="Ketones [Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_5"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">Negative</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Negative</text>
+                                            <value xsi:type="ST">Negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5804-0"
+                                        displayName="Protein[Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_6"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="100" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>negative</text>
+                                            <value xsi:type="ST">negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="5f09fddb-1a80-4a65-8d24-8a2a08637f09"/>
+                            <code code="36643-5" displayName="Chest X-ray 2 views"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_1"/>
+                                </originalText>
+                                <translation code="71010" displayName="Chest X-ray"
+                                    codeSystemName="R"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622115900-0400"/>
+                                <high value="20150622115900-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622115900"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706281613-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="36643-5" displayName="Chest X-ray 2 Views"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_1_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622215400-0400"/>
+                                    <value xsi:type="ST">Abnormal</value>
+                                    <interpretationCode code="A" displayName="Abnormal"
+                                        codeSystem="2.16.840.1.113883.5.83"
+                                        codeSystemName="HL7 Observation Interpretation"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622115900"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706281613-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>User</family>
+                                                  <given>Adam</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                            <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ResultComment_1_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                        </act>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#clinNotes_Results_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20210125145624"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="AdvanceDirectives"/>
+                    <code code="42348-3" displayName="ADVANCE DIRECTIVES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Advance Directives</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Directive</th>
+                                    <th>Yes / No</th>
+                                    <th>Effective Date</th>
+                                    <th>File Name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownAdvanceDirective" xmlns="urn:hl7-org:v3"
+                                            >No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Encounters"/>
+                    <code code="46240-8" displayName="HISTORY OF ENCOUNTERS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Encounters</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Description</th>
+                                    <th>Practice</th>
+                                    <th>Location</th>
+                                    <th>Reason(s) For Visit</th>
+                                    <th>Diagnoses</th>
+                                    <th>Date</th>
+                                    <th>Provider</th>
+                                    <th>Providers Copied on Encounter</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                    <td>
+                                        <content>HoitzThisIsAReallyLongLa TerryThisIsAReallyLongFi.
+                                            1 Jarrett White Rd, Tripler Army Medical Center, HI,
+                                            968595000, US. tel:+1-8084331212</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_1" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>
+                                                <content>sore throat (chief complaint)</content>
+                                            </item>
+                                            <item>
+                                                <content>Sore throat (chief complaint)</content>
+                                            </item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Acute tonsillitis due to other specified
+                                                organisms</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension (chief complaint)</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Hypertension</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Fever - Finding</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="9d7d931c-948f-4a59-a532-d9b96c868129"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_0"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202109201436"/>
+                                <high value="202109201436"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                                        <city>Tripler Army Medical Center</city>
+                                        <state>HI</state>
+                                        <postalCode>96859-5000</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-8084331212"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>HoitzThisIsAReallyLongLa</family>
+                                            <given>TerryThisIsAReallyLongFi</given>
+                                            <given>TerrysMiddleName-35-</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id nullFlavor="UNK"/>
+                                            <code nullFlavor="UNK">
+                                                <translation nullFlavor="UNK"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"/>
+                            <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_1"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202003041348"/>
+                                <high value="202003041348"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200304"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_1"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="285533fa-4983-4e30-b718-c2942646ea36"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="J03.80"
+                                                displayName="Acute tonsillitis due to other specified organisms"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time nullFlavor="UNK"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202003041440-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="26db8415-1153-455c-a328-da1aeb35e30f"/>
+                            <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_2"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202002281351"/>
+                                <high value="202002281351"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200228"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_2"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="5ad6f921-233e-4d8c-927d-ecfd26bfbaf9"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20200228"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="I10" displayName="Hypertension"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20200228"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202002281406-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_3"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="201506221000"/>
+                                <high value="201506221000"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                            <code code="~" displayName="~"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation nullFlavor="NA"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20150622"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="R50.9" displayName="Fever - Finding"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20150622"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202103261221-0400"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom value="5555551002"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FamilyHistory"/>
+                    <code code="10157-6" displayName="HISTORY OF FAMILY MEMBER DISEASES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Family History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Family Member</th>
+                                    <th>Type</th>
+                                    <th>Diagnosis</th>
+                                    <th>Age At Onset</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_0"
+                                            xmlns="urn:hl7-org:v3">Alive and well</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_1"
+                                            xmlns="urn:hl7-org:v3">Family history of
+                                            asthma</content>
+                                    </td>
+                                    <td>
+                                        <content>16</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"
+                                extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <statusCode code="completed"/>
+                            <subject>
+                                <relatedSubject classCode="PRS">
+                                    <code code="BRO" displayName="Brother"
+                                        codeSystem="2.16.840.1.113883.5.111"
+                                        codeSystemName="HL7RoleCode"/>
+                                    <subject>
+                                        <sdtc:id root="1.3.6.1.4.1.21367.13.40.117"
+                                            extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"
+                                            xmlns:sdtc="urn:hl7-org:sdtc"/>
+                                        <name>Kenneth</name>
+                                        <administrativeGenderCode code="M" displayName="Male"
+                                            codeSystem="2.16.840.1.113883.5.1"
+                                            codeSystemName="HL7AdministrativeGender"/>
+                                        <birthTime nullFlavor="UNK"/>
+                                    </subject>
+                                </relatedSubject>
+                            </subject>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160445003" displayName="Alive and well"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_0"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="d1af37b2-178e-4cd9-ae47-3f63d9d6947f"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160377001" displayName="Family history of asthma"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_1"/>
+                                        </originalText>
+                                    </value>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.31"/>
+                                            <code code="445518008" displayName="Age At Onset"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT"/>
+                                            <statusCode code="completed"/>
+                                            <value value="16" unit="a" xsi:type="PQ"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Immunizations"/>
+                    <code code="11369-6" displayName="HISTORY OF IMMUNIZATION NARRATIVE"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Immunizations</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Vaccine</th>
+                                    <th>Date</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_0" xmlns="urn:hl7-org:v3"
+                                            >influenza, intradermal, quadrivalent, preservative
+                                            free, injectable</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>refused</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_0" xmlns="urn:hl7-org:v3"
+                                            >Note: Immunization was not given - Patient rejected
+                                            immunization. ; Source: New Immunization Record
+                                        </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_1" xmlns="urn:hl7-org:v3"
+                                            >diphtheria, tetanus toxoids and acellular pertussis
+                                            vaccine, 5 pertussis antigens</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-04-2012</content>
+                                    </td>
+                                    <td>
+                                        <content>administered</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_1" xmlns="urn:hl7-org:v3"
+                                            >Source: Source Unspecified </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="true">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="51f02998-93bb-4385-9050-873373b9fc44"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_0"/>
+                            </text>
+                            <statusCode code="aborted"/>
+                            <effectiveTime value="20150622"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="166"
+                                            displayName="influenza, intradermal, quadrivalent, preservative free, injectable"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_0"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK"/>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319185347"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706151004-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="ba7049e4-8bcb-4a44-84e8-9e3f40d28f5f"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20120104"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="106"
+                                            displayName="diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_1"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText>2</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319184655"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201705081257-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Payer"/>
+                    <code code="48768-6" displayName="PAYMENT SOURCES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Payers</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Payer name</th>
+                                    <th>Insurance type</th>
+                                    <th>Covered party ID</th>
+                                    <th>Authorization(s)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownPayer" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="SocialHistory"/>
+                    <code code="29762-2" displayName="SOCIAL HISTORY"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Social History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Description</th>
+                                    <th>Quantity</th>
+                                    <th>Date Captured</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_0" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_0"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_0"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_1" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_1"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_1"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_2" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Cigarette smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_2"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_3" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Current every day smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_3"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobacco_5"
+                                            xmlns="urn:hl7-org:v3">Smoking Tobacco Use
+                                            Details</content>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobaccoDate_5"
+                                            xmlns="urn:hl7-org:v3">Aug-17-2017</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_6" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_6"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_6"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_7" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_7"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_7"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_8" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_8"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_9" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_9"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_11" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_11"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_11"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_12"
+                                            xmlns="urn:hl7-org:v3">Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_12"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_12"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_13" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_13"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_14" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_14"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Birth Sex</content>
+                                    </td>
+                                    <td>
+                                        <content ID="BSex_value0" xmlns="urn:hl7-org:v3"
+                                            >Female</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_3"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20150622"/>
+                            <value code="449868002" displayName="Current every day smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_9"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200304"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_14"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200228"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_0"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_6"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_11"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe" extension="TobaccoUse"/>
+                            <code code="11367-0" displayName="History of tobacco use"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistoryTobacco_2"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value code="65568007" displayName="Cigarette smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_1"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_7"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_12"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="SmokingTobacco"/>
+                            <code code="229819007" displayName="Tobacco use and exposure"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistorySmokingTobacco_5"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20170817"/>
+                            </effectiveTime>
+                            <value xsi:type="ST">Cigarette: No Details Available Quantity Details -
+                                Cigarette: No Details Available </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708170737-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.200"
+                                extension="2016-06-01"/>
+                            <code code="76689-9" displayName="Sex Assigned At Birth"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#BSex_value0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1"
+                                codeSystemName="HL7AdministrativeGender" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BSex_value0"/>
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202104020755-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="VitalSigns"/>
+                    <code code="8716-3" displayName="VITAL SIGNS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Vital Signs</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date / Time:</th>
+                                    <th>Height</th>
+                                    <th>Weight</th>
+                                    <th>BMI</th>
+                                    <th>Pulse Rate</th>
+                                    <th>Blood Pressure</th>
+                                    <th>Temperature</th>
+                                    <th>Respiratory Rate</th>
+                                    <th>Body Surface Area</th>
+                                    <th>Head Circumference</th>
+                                    <th>Head Circ. Percentile</th>
+                                    <th>Wt./Len. Percentile</th>
+                                    <th>BMI percentile</th>
+                                    <th>Pulse Ox</th>
+                                    <th>Inhaled Ox</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015 10:05 AM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_0" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_0" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_0" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeartBeat_0" xmlns="urn:hl7-org:v3"
+                                            >80 /min</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_0"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_0" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsRespiratoryRate_0"
+                                            xmlns="urn:hl7-org:v3">18 /min</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsPulseOx_0" xmlns="urn:hl7-org:v3">95
+                                            %</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsInhaledOxyConc_0"
+                                            xmlns="urn:hl7-org:v3">36 %</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020 1:55 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_1" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_1" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_1" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_1"
+                                            xmlns="urn:hl7-org:v3">150/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_1" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020 1:59 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_2" xmlns="urn:hl7-org:v3"
+                                            >65.00 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_2" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (165.00 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_2" xmlns="urn:hl7-org:v3">27.46
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_2"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="201506221005-0400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201707271030-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_height_0"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_weight_0"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_systolic_0"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_diastolic_0"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="heart_rate_0"/>
+                                    <code code="8867-4" displayName="Heart Rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeartBeat_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="80" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_temperature_0"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="respiratory_rate_0"/>
+                                    <code code="9279-1" displayName="Respiratory rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsRespiratoryRate_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="18" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="sao2_%_blda_pulseox_0"/>
+                                    <code code="59408-5" displayName="SaO2 % BldA PulseOx"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsPulseOx_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="95" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="inhaled_oxygen_concentration_0"/>
+                                    <code code="3150-0" displayName="Inhaled Oxygen Concentration"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsInhaledOxyConc_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="36" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202003041355-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200304"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111850-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_height_1"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_weight_1"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_systolic_1"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="150" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_diastolic_1"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_temperature_1"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_mass_index_1"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202002281359-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174" extension="43"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281401-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_height_2"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_weight_2"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_systolic_2"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_diastolic_2"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_mass_index_2"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="27.46" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="ChiefComplaintAndReasonForVisit"/>
+                    <code code="46239-0" displayName="CHIEF COMPLAINT AND REASON FOR VISIT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Chief Complaint And Reason For Visit</title>
+                    <text>
+                        <paragraph>No Information</paragraph>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ReferralReason"/>
+                    <code code="42349-1" displayName="REASON FOR REFERRAL"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Reason For Referral</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Reason For Referral</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="1">
+                                        <content ID="UnknownReferral" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="PlanOfCare"/>
+                    <code code="18776-5" displayName="TREATMENT PLAN"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Plan Of Treatment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Action</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Radiology Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_0" xmlns="urn:hl7-org:v3">EKG
+                                            (93000), Scheduled for: Jun-23-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Lab Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_1" xmlns="urn:hl7-org:v3"
+                                            >Urinanalysis macro (dipstick) panel (81002), Scheduled
+                                            for: Jun-29-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="bdb795ab-6f6d-415e-956c-fb87940dd574"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#FutureOrder_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506230400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708151638-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="3f143484-5a7b-4aca-acab-1bf2f8539896"/>
+                            <code code="24357-6"
+                                displayName="Urinalysis macro (dipstick) panel - Urine"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#FutureOrder_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506291200"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201725-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HistoryOfPresentIllness"/>
+                    <code code="10164-2" displayName="HISTORY OF PRESENT ILLNESS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History Of Present Illness</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Date</th>
+                                    <th>Complaint</th>
+                                    <th>History Of Present Illness</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>The HTN started in 2015. The symptoms began
+                                            gradually. The severity has been described as being 6.
+                                            It is currently stable. Risk factors include inactive
+                                            lifestyle, obesity, sleep apnea and smoking. The
+                                            hypertension is exacerbated by anxiety. Associated
+                                            symptoms include fatigue and headache.</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FunctionalStatus"/>
+                    <code code="47420-5" displayName="Functional Status"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Functional Status</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Functional Assessment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>May-01-2005</content>
+                                    </td>
+                                    <td>
+                                        <content>Dependence on cane</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"
+                                extension="2014-06-09"/>
+                            <id nullFlavor="UNK"/>
+                            <code nullFlavor="NP"/>
+                            <statusCode code="completed"/>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"
+                                        extension="2014-06-09"/>
+                                    <id root="e942984a-f2fb-416e-80ce-d481c8b0fb71"/>
+                                    <code code="54522-8" displayName="Functional Status"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20050501"/>
+                                    <value code="105504002" displayName="Dependence on cane"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.128"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime nullFlavor="UNK"/>
+                                    <value nullFlavor="UNK" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CcdaMedicationsAdministered"/>
+                    <code code="29549-3" displayName="MEDICATION ADMINISTERED"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications Administered</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="UnknownMedicationAdministered"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Instructions"/>
+                    <code code="69730-0" displayName="INSTRUCTIONS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Instructions</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Instruction</th>
+                                    <th>Additional Information</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PatientInstruction_0" xmlns="urn:hl7-org:v3">i.
+                                            Get an EKG done on 6/23/2015. ii. Get a Chest X-ray done
+                                            on 6/23/2015 showing the Lower Respiratory Tract
+                                            Structure. iii. Take Clindamycin 300mg three times a day
+                                            as needed if pain does not subside. iv. Schedule follow
+                                            on visit with Neighborhood Physicians Practice on
+                                            7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Related to Fever - Finding</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act moodCode="INT" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="1d98f86c-5319-45d4-98fa-a26df91591dc"/>
+                            <code code="423564006" displayName="Provider Instructions for treatment"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+                            <text>
+                                <reference value="#PatientInstruction_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000"/>
+                            </effectiveTime>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Assessment"/>
+                    <code code="51848-0" displayName="ASSESSMENTS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Assessments</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Assessment</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Fever - Finding</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>impression</content>
+                                    </td>
+                                    <td>
+                                        <content>The patient was found to have fever and Dr Davis is
+                                            suspecting Anemia based on the patient history. So Dr
+                                            Davis asked the patient to closely monitor the
+                                            temperature and blood pressure and get admitted to
+                                            Community Health Hospitals if the fever does not subside
+                                            within a day. i. Get an EKG done on 6/23/2015. ii. Take
+                                            Clindamycin 300mg three times a day as needed if pain
+                                            does not subside. iii. Schedule follow on visit with
+                                            Neighborhood Physicians Practice on 7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Acute tonsillitis due to other specified
+                                            organisms</content>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.60"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Goals"/>
+                    <code code="61146-7" displayName="GOALS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Goals</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Goal</th>
+                                    <th>Type</th>
+                                    <th>Priority</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Fever</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_0" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occurring every few
+                                            weeks.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_1" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_2" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occuring every few
+                                            weeks</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_3" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="3b72c7a7-2b83-4e68-a1c9-bcc637fd389f"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occurring
+                                every few weeks.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="d2b8277e-2016-4489-b2db-34360fde0cd0"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="eff3999e-ad61-477c-864f-402b281924a3"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occuring
+                                every few weeks</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="41ccf5d4-05af-48f1-949d-659040b8a781"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="MedicalEquipment"/>
+                    <code code="46264-8" displayName="MEDICAL EQUIPMENT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medical Equipment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th>Device</th>
+                                    <th>Universal Device Identifier</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Device Status</th>
+                                    <th>Implantable Device Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ImplantableProcDev__0_0" xmlns="urn:hl7-org:v3"
+                                            >CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>(01)00643169007222(17)160128(21)BLC200461H</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.313"
+                                extension="2018-05-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code code="33216"
+                                displayName="Introduction of cardiac pacemaker system via vein"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"
+                                xsi:type="CE"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.310"
+                                        extension="2018-05-01"/>
+                                    <id root="2.16.840.1.113883.3.3719"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="FDA"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK">
+                                            <originalText>
+                                                <reference value="#ImplantableProcDev__0_0"/>
+                                            </originalText>
+                                        </code>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="2.16.840.1.113883.3.3719"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP">
+                                <organizer classCode="CLUSTER" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.311"
+                                        extension="2019-06-21"/>
+                                    <id extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        root="2.16.840.1.113883.3.3719"/>
+                                    <code code="74711-3" displayName="Unique Device Identifier"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.304"
+                                                extension="2019-06-21"/>
+                                            <code code="C101722" displayName="Primary DI Number"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value root="1.3.160" extension="00643169007222"
+                                                displayable="true" assigningAuthorityName="GS1"
+                                                xsi:type="II"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.318"
+                                                extension="2019-06-21"/>
+                                            <code code="C106044" displayName="MRI Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C113844"
+                                                displayName="Labeling does not contain MRI Safety Information"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.46"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.314"
+                                                extension="2019-06-21"/>
+                                            <code code="C160938" displayName="Latex Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C106038"
+                                                displayName="Not Made with Natural Rubber Latex"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.47"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.305"
+                                                extension="2019-06-21"/>
+                                            <code code="C160939"
+                                                displayName="Implantable Device Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C45329" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.48"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.306"
+                                                extension="2018-05-01"/>
+                                            <code code="UDI-00007" displayName="Device Status"
+                                                codeSystem="1.3.6.1.4.1.19376.1.4.1.6.5.290"
+                                                codeSystemName="UDI Observation Type"/>
+                                            <value code="active"
+                                                codeSystem="2.16.840.1.113883.4.642.3.199"
+                                                codeSystemName="Device Status" xsi:type="CD"/>
+                                        </observation>
+                                    </component>
+                                </organizer>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HealthConcerns"/>
+                    <code code="75310-3" displayName="HEALTH CONCERNS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Observation</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthStatusObs_0" xmlns="urn:hl7-org:v3"
+                                            >Chronically ill</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Concern</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_0" xmlns="urn:hl7-org:v3"
+                                            >Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_1" xmlns="urn:hl7-org:v3"
+                                            >Weight - 88.000 kg</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_2" xmlns="urn:hl7-org:v3"
+                                            >Fever - Finding - R50.9</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_3" xmlns="urn:hl7-org:v3">BMI
+                                            - 28.08 - Watch weight of patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_4" xmlns="urn:hl7-org:v3"
+                                            >Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_5" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_6" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_7" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_8" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="EVN" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5" extension="2014-06-09"/>
+                            <id root="45cf87bf-0952-4e7c-b049-ad19b435729e"/>
+                            <code code="11323-3" displayName="HEALTH STATUS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthStatusObs_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="161901003" displayName="Chronically ill"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111912-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c7dcddd1-8a45-4536-8975-9df72a77d474"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6c1d5761-3b89-4592-97ac-67905ef3e3d8"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="a30988e2-aab4-4ff7-8ac8-a286393f22fb"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061059-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_4"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061100-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="5214ea51-a323-4a9e-860d-7b8f688688cd"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_5"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="deda0b49-2996-411b-b9b9-e517db9bec04"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_6"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061057-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c5bb9c90-1562-42b4-a2c1-fcf7868443e5"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_7"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_8"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061058-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.500" extension="2019-07-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CareTeam"/>
+                    <code code="85847-2" displayName="PATIENT CARE TEAM"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Patient Care Teams</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Members</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_0" xmlns="urn:hl7-org:v3">Core
+                                            Team</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>nullified</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item> Kristin Allison.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_1" xmlns="urn:hl7-org:v3">Care Team
+                                            A</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>[Family medicine specialist] Albert Davis, 2472
+                                                Rocky Place, Beaverton, OR, 97006.</item>
+                                            <item>[grandfather] Rick Holler, 1357 Amber Dr,
+                                                Beaverton, OR, 97006.</item>
+                                            <item>[spouse] Matthew Newman, 1357 Amber Dr.,
+                                                Beaverton, OR, 97006.</item>
+                                            <item> Tracy Davis, 2472 Rocky Place, Beaverton, OR,
+                                                97006.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="5ae3655e-dfe0-4bf9-9ec3-b3693d6956f5"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_0"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="nullified"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101291121-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="9a7b1756-d0a6-4db9-93f9-260dbaa04dc7"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode nullFlavor="UNK"/>
+                                    <effectiveTime>
+                                        <low nullFlavor="UNK"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low nullFlavor="UNK"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id root="2.16.840.1.113883.4.6" extension="1528951720"/>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Allison</family>
+                                                  <given>Kristin</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="1755af9d-4c9f-4442-ac10-fc9d2b264338"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_1"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101191649-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="6ebb65ef-0d6f-4358-87da-96e4b71f8b4b"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="207Q00000X"
+                                                displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Neighborhood Physicians Practice</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="48563921-dded-4fc5-b54e-0b86775d7fca"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Holler</family>
+                                                  <given>Rick</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="335b6602-a8b2-4d3d-8744-9ad850e7ebc6"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Newman</family>
+                                                  <given>Matthew</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="b72378a1-6e51-4e33-a209-93374a095f12"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="251B00000X"
+                                                displayName="Agencies : Case Management"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Tracy</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="DischargeSummaryClinicalNotes"/>
+                    <code code="18842-5" displayName="Discharge summary"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Discharge Summary Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownDischargeSummaryClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="18842-5" displayName="Discharge summary"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownDischargeSummaryClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ConsultNoteClinicalNotes"/>
+                    <code code="11488-4" displayName="Consult Note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Consultation Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownConsultNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11488-4" displayName="Consult Note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownConsultNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="HistoryPhysicalNoteClinicalNotes"/>
+                    <code code="34117-2" displayName="History and physical note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History and Physical Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownHistoryPhysicalNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="34117-2" displayName="History and physical note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownHistoryPhysicalNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ProgressNoteNoteClinicalNotes"/>
+                    <code code="11506-3" displayName="Progress note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Progress Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_ProgressNoteNoteClinicalNotes_0"
+                                            xmlns="urn:hl7-org:v3">Ms Alice Newman seems to be
+                                            developing high fever and hence we recommend her to get
+                                            admitted to a nearby hospital using the provided
+                                            referral. </content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                        	<!--  Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11506-3" displayName="Progress note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_ProgressNoteNoteClinicalNotes_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210920"/>
+                            <!-- swapped authors -->
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 valid TS as per provenance reqs, but is not provenance, so irrelevant, no error expected
+                                 -->
+                                <time value="202109201442-0400"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>                            
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="9d7d931c-948f-4a59-a532-d9b96c868129"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/src/test/resources/cures/sub/SUB_VALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
+++ b/src/test/resources/cures/sub/SUB_VALID_PROVENANCE_TS_INVALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
@@ -1,0 +1,10371 @@
+<?xml version="1.0"?><?xml-stylesheet type='text/xsl' href='http://www.nextgenshare.com/public/CDA_NGMU2.xsl'?>
+<ClinicalDocument xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc"
+    xmlns="urn:hl7-org:v3" xmlns:mif="urn:hl7-org:v3/mif"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US"/>
+    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+    <id root="1.3.6.1.4.1.21367.13.40.117" extension="f0b0de8a-dfd1-458b-99a5-523011eba40b"/>
+    <code code="34133-9" displayName="SUMMARIZATION OF EPISODE NOTE"
+        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+    <title>Continuity of Care Document (C-CDA R2.1)</title>
+    <effectiveTime value="20210920164540-0400"/>
+    <confidentialityCode code="N" displayName="Normal Sharing" codeSystem="2.16.840.1.113883.5.25"
+        codeSystemName="HL7 Confidentiality"/>
+    <languageCode code="en-US"/>
+    <recordTarget>
+        <patientRole>
+            <id extension="8658" root="1.100"/>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom use="MC" value="tel:+1-5557771234"/>
+            <telecom use="HP" value="tel:+1-5557231544"/>
+            <telecom value="mailto:sadavis@nextgen.com"/>
+            <patient>
+                <name use="L">
+                    <family>Newman</family>
+                    <given qualifier="CL">Alice</given>
+                    <given>Jones</given>
+                </name>
+                <name use="SRCH">
+                    <family>Newman</family>
+                    <given qualifier="BR">Alicia</given>
+                </name>
+                <administrativeGenderCode code="F" displayName="Female"
+                    codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
+                <birthTime value="19700501"/>
+                <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicitys"/>
+                <sdtc:raceCode code="2108-9" displayName="European"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+                <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicitys"/>
+                <languageCommunication>
+                    <templateId root="2.16.840.1.113883.3.88.11.32.2"/>
+                    <languageCode code="en"/>
+                    <preferenceInd value="true"/>
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id root="1.174" extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+        </assignedAuthor>
+    </author>
+    <author>
+        <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id nullFlavor="UNK"/>
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom value="5555551002"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom value="5555551002"/>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <informant>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Admin</family>
+                    <given>NEXTGEN</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </informant>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <legalAuthenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom use="WP" nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </legalAuthenticator>
+    <authenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </authenticator>
+    <participant typeCode="IND">
+        <time value="19400101"/>
+        <associatedEntity classCode="PRS">
+            <code code="GRPRN" displayName="grandparent" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="04" displayName="Grandparent"
+                    codeSystem="2.16.840.1.113883.3.109" codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Holler</family>
+                    <given>Rick</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <time value="19790101"/>
+        <associatedEntity classCode="PRS">
+            <code code="SPS" displayName="spouse" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="01" displayName="Spouse" codeSystem="2.16.840.1.113883.3.109"
+                    codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Newman</family>
+                    <given>Matthew</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <associatedEntity classCode="CAREGIVER">
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+            </addr>
+            <telecom use="HP" value="tel:+1-5555551002"/>
+            <associatedPerson>
+                <name>
+                    <family>Allison</family>
+                    <given>Kristin</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <functionCode code="PCP" codeSystem="2.16.840.1.113883.5.88"/>
+        <associatedEntity classCode="CAREGIVER">
+            <associatedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <documentationOf typeCode="DOC">
+        <serviceEvent classCode="PCPR">
+            <effectiveTime>
+                <low value="201506221000"/>
+                <high value="202109201436"/>
+            </effectiveTime>
+            <performer typeCode="PRF">
+                <time>
+                    <low value="202109201645"/>
+                    <high value="202109201645"/>
+                </time>
+                <assignedEntity>
+                    <id root="1.174" extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"/>
+                    <addr>
+                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                        <city>Tripler Army Medical Center</city>
+                        <state>HI</state>
+                        <postalCode>96859-5000</postalCode>
+                        <country>US</country>
+                    </addr>
+                    <telecom nullFlavor="UNK"/>
+                    <assignedPerson>
+                        <name>
+                            <given>TerryThisIsAReallyLongFi</given>
+                            <family>HoitzThisIsAReallyLongLa</family>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </performer>
+        </serviceEvent>
+    </documentationOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Alerts"/>
+                    <code code="48765-2" displayName="Allergies and adverse reactions Document"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Allergies, Adverse Reactions, Alerts</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Substance</th>
+                                    <th>Reaction</th>
+                                    <th>Status</th>
+                                    <th>Criticality</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_0" xmlns="urn:hl7-org:v3"
+                                            >penicillin G </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_0_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_0_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_0" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_0" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_1" xmlns="urn:hl7-org:v3"
+                                            >ampicillin </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_1_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_1_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_1" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_1" xmlns="urn:hl7-org:v3"
+                                            >Low</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201810241352-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Canonica</family>
+                                                  <given>Gina</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="7980" displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_0"/>
+                                                  </originalText>
+                                                  <translation code="4977"
+                                                  displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>penicillin G</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_0_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_0_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_0_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101121613-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="733" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_1"/>
+                                                  </originalText>
+                                                  <translation code="2692" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>ampicillin</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_1_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_1_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_1_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="CRITL" displayName="Low"
+                                                codeSystem="2.16.840.1.113883.5.1063"
+                                                codeSystemName="HL7SeverityObservation"
+                                                xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Medications"/>
+                    <code code="10160-0" displayName="History of Medication use Narrative"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_0" xmlns="urn:hl7-org:v3"
+                                            >Aranesp 500 mcg/mL (in polysorbate) injection
+                                            syringe</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_0" xmlns="urn:hl7-org:v3">inject
+                                            1 milliliter by subcutaneous route every week</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_0" xmlns="urn:hl7-org:v3">2.25
+                                            MCG/KG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_1" xmlns="urn:hl7-org:v3"
+                                            >clindamycin 300 mg capsule</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_1" xmlns="urn:hl7-org:v3">take 1
+                                            capsule by oral route 3 times every day if pain does not
+                                            subside as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_1" xmlns="urn:hl7-org:v3">300
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-01-2017 - Oct-30-2018</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_2" xmlns="urn:hl7-org:v3"
+                                            >Tylenol Extra Strength 500 mg tablet</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_2" xmlns="urn:hl7-org:v3">take 1
+                                            tablet by oral route every 4 hours as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_2" xmlns="urn:hl7-org:v3">500
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jul-01-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_2" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_3" xmlns="urn:hl7-org:v3"
+                                            >ceftriaxone 100 gram solution for injection</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_3" xmlns="urn:hl7-org:v3">inject
+                                            10 milligram by injection route 2 times every
+                                            day</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_3" xmlns="urn:hl7-org:v3">10
+                                            milligram</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jun-30-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="5418eadb-2b53-4aa6-9875-2f918456f0fa"/>
+                            <text>
+                                <reference value="#MedicationSig_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="1" unit="wk"/>
+                            </effectiveTime>
+                            <routeCode code="C38299" displayName="SUBCUTANEOUS"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="mL"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="731241"
+                                            displayName="1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe [Aranesp]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_0"/>
+                                            </originalText>
+                                            <translation code="55513003201"
+                                                displayName="darbepoetin alfa in polysorbat"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe
+                                            [Aranesp]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706142020-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="ddd500c2-4399-4a50-addd-aa2c26fa3fdf"/>
+                            <text>
+                                <reference value="#MedicationSig_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20170901"/>
+                                <high value="20181030"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="true" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="8" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{capsule}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="748748"
+                                            displayName="clindamycin 300 MG Oral Capsule [Cleocin]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_1"/>
+                                            </originalText>
+                                            <translation code="00527138301"
+                                                displayName="clindamycin HCl"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>clindamycin 300 MG Oral Capsule [Cleocin]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170901"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201810241401-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="6936cfb5-ad96-457e-8a90-1d71fd7e71f9"/>
+                            <text>
+                                <reference value="#MedicationSig_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150701"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="4" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{tablet}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="209459"
+                                            displayName="acetaminophen 500 MG Oral Tablet [Tylenol]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_2"/>
+                                            </originalText>
+                                            <translation code="00450044406"
+                                                displayName="acetaminophen"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>acetaminophen 500 MG Oral Tablet [Tylenol]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101141402-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="f6552a8d-5ae6-42ce-a4a8-e86bcba51a7d"/>
+                            <text>
+                                <reference value="#MedicationSig_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150630"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="12" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38291" displayName="PARENTERAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="10" unit="mg"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="309090"
+                                            displayName="ceftriaxone 100 MG/ML Injectable Solution"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_3"/>
+                                            </originalText>
+                                            <translation code="66288610001"
+                                                displayName="ceftriaxone sodium"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201554-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Problems"/>
+                    <code code="11450-4" displayName="PROBLEM LIST"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Problems</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Condition</th>
+                                    <th>Type</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Clinical Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Chronic rejection of renal
+                                            transplant</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Overweight</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - Jun-01-2007</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Problem resolved
+                                            (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="dc419944-c4a3-4343-9782-7c3468b5be90"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="386661006" displayName="Fever"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202102081114-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="770ff05e-9f26-4245-a4e6-48c88b7a8a6e"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="236578006"
+                                        displayName="Chronic rejection of renal transplant"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111005"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="59621000" displayName="Essential hypertension"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111005"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems2"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="83986005" displayName="Severe hypothyroidism"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101191712-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems3"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems4"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                                <high value="20070601"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="cb229847-35f2-4d70-bc2d-b3713e82763d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high value="20070601"/>
+                                    </effectiveTime>
+                                    <value code="238131007" displayName="Overweight"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201705081255-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems4"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="413322009"
+                                                displayName="Problem resolved (finding)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+					<!-- Procedures Section -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Procedures"/>
+                    <code code="47519-4" displayName="HISTORY OF PROCEDURES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Procedures</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure</th>
+                                    <th>Universal Device Identifier/Device Identifier</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_0" xmlns="urn:hl7-org:v3"
+                                            >Nebulizer Therapy</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_1" xmlns="urn:hl7-org:v3"
+                                            >Introduction of cardiac pacemaker system via
+                                            vein</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4 -
+                                                (01)00643169007222(17)160128(21)BLC200461H</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_3" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_Procedures_0" xmlns="urn:hl7-org:v3"
+                                            >Dr Albert Davis examined Ms Alice Newman and found that
+                                            the pacemaker is operating properly and the
+                                            breathlessness is due to high fever and
+                                            anxiety.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="aaff7f65-82dc-4039-85ac-5db62a9d983e"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_0"/>
+                                </originalText>
+                                <translation code="94640" displayName="Nebulizer Therapy"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101112008-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_1"/>
+                                </originalText>
+                                <translation code="33216"
+                                    displayName="Introduction of cardiac pacemaker system via vein"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                                <high value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.37"/>
+                                    <id root="1.3.160"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="GS1"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK"/>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="1.3.160"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="ff884e65-94e1-4e11-9438-74b67d03da41"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_2"/>
+                                </originalText>
+                                <translation code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                                <high value="20200304"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041448-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="07250fe9-b4ac-485f-b42d-3dff1df1ddd8"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_3"/>
+                                </originalText>
+                                <translation code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                                <high value="20200228"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281407-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+							<!-- Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<!-- relevant identifying code 28570-0 in error -->
+                                <translation code="28570-0" displayName="Procedure note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_Procedures_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+								<!-- -dbTest 1: Here is the location of the time which errors for provenance
+											 but it is actually the original Author Participation (see II, 4.119, NOT 5.6  -->
+								<!-- user states:
+The submitted Provenance (Time: Value) 20210125145611 at Note Activity Author Entry for Notes Section corresponding 
+to the code 28570-0 is invalid. Please ensure the time and time-zone starts with a 4 or 6-digit time, 
+followed by a '+' or a '-', and finally, a 4-digit time-zone. The invalid time and time-zone portion of the value is 145611. 
+
+In this example validator is assuming that provenance time stamp is 20210125145611 which is not correct.   
+Instead, correct provenance timestamp is  202101251456-0500 since it is under the author node decorated by template ID 
+<templateId root="2.16.840.1.113883.10.20.22.5.6"  extension="2019-10-01"/>	-->			
+                                <time value="20210125145611"/> <!-- this time shows up in 'provenance' error -->
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- this time does not show up in error (nor should it) as has time-zone -->
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Results"/>
+                    <code code="30954-2"
+                        displayName="Relevant diagnostic tests &amp;or laboratory data"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Results</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Test Name</th>
+                                    <th>Date and Time</th>
+                                    <th>Measure</th>
+                                    <th>Units</th>
+                                    <th>Reference Range</th>
+                                    <th>Abnormal Flag</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_0" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Urinanalysis macro (dipstick)
+                                            panel</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_0" xmlns="urn:hl7-org:v3"
+                                            >SPECIMEN: source: Urine specimen, Urine</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_0" xmlns="urn:hl7-org:v3"
+                                            >Color of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_0"
+                                            xmlns="urn:hl7-org:v3">YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_0" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_1" xmlns="urn:hl7-org:v3"
+                                            >Appearance of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_1"
+                                            xmlns="urn:hl7-org:v3">CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_1" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_2" xmlns="urn:hl7-org:v3"
+                                            >Specific gravity of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>1.015</content>
+                                    </td>
+                                    <td>
+                                        <content>1</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_2"
+                                            xmlns="urn:hl7-org:v3">1.005-1.030</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_2" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_3" xmlns="urn:hl7-org:v3"
+                                            >pH of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>5.0</content>
+                                    </td>
+                                    <td>
+                                        <content>pH</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_3"
+                                            xmlns="urn:hl7-org:v3">5.0-8.0</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_3" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_4" xmlns="urn:hl7-org:v3"
+                                            >Glucose [Mass/volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>50</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_4"
+                                            xmlns="urn:hl7-org:v3">Neg</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_4" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_5" xmlns="urn:hl7-org:v3"
+                                            >Ketones [Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_5"
+                                            xmlns="urn:hl7-org:v3">Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_5" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_6" xmlns="urn:hl7-org:v3"
+                                            >Protein[Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>100</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_6"
+                                            xmlns="urn:hl7-org:v3">negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_6" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_1" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Chest X-ray 2 views</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_1_0" xmlns="urn:hl7-org:v3"
+                                            >Chest X-ray 2 Views</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 21:54:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Abnormal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_1_0"
+                                            xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>A</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_1_0" xmlns="urn:hl7-org:v3">Lungs
+                                            are not clear, cannot rule out Anemia. Other tests are
+                                            required to determine the presence or absence of Anemia.
+                                        </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note Type</th>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Laboratory Report Narrative</content>
+                                    </td>
+                                    <td>
+                                        <content ID="clinNotes_Results_0" xmlns="urn:hl7-org:v3">Ms
+                                            Alice Newman was tested for the Urinanalysis macro panel
+                                            and the results have been found to be normal.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="f05926e4-90b4-4d39-b7db-46c5ae2c28bf"/>
+                            <code code="24357-6" displayName="Urinanalysis macro (dipstick) panel"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_0"/>
+                                </originalText>
+                                <translation code="81002"
+                                    displayName="Urinalysis, non-automated, w/scope"
+                                    codeSystemName="L"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000-0400"/>
+                                <high value="20150622110000-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622110000"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706301717-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Interface</family>
+                                            <given>Rosetta</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5778-6" displayName="Color of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">YELLOW</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>YELLOW</text>
+                                            <value xsi:type="ST">YELLOW</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5767-9" displayName="Appearance of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">CLEAR</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>CLEAR</text>
+                                            <value xsi:type="ST">CLEAR</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5811-5"
+                                        displayName="Specific gravity of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="1.015" unit="1"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>1.005-1.030</text>
+                                            <value xsi:type="ST">1.005-1.030</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5803-2" displayName="pH of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="5.0" unit="[pH]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>5.0-8.0</text>
+                                            <value xsi:type="ST">5.0-8.0</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5792-7"
+                                        displayName="Glucose [Mass/volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="50" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Neg</text>
+                                            <value xsi:type="ST">Neg</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5797-6"
+                                        displayName="Ketones [Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_5"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">Negative</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Negative</text>
+                                            <value xsi:type="ST">Negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5804-0"
+                                        displayName="Protein[Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_6"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="100" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>negative</text>
+                                            <value xsi:type="ST">negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="5f09fddb-1a80-4a65-8d24-8a2a08637f09"/>
+                            <code code="36643-5" displayName="Chest X-ray 2 views"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_1"/>
+                                </originalText>
+                                <translation code="71010" displayName="Chest X-ray"
+                                    codeSystemName="R"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622115900-0400"/>
+                                <high value="20150622115900-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622115900"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706281613-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="36643-5" displayName="Chest X-ray 2 Views"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_1_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622215400-0400"/>
+                                    <value xsi:type="ST">Abnormal</value>
+                                    <interpretationCode code="A" displayName="Abnormal"
+                                        codeSystem="2.16.840.1.113883.5.83"
+                                        codeSystemName="HL7 Observation Interpretation"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622115900"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706281613-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>User</family>
+                                                  <given>Adam</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                            <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ResultComment_1_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                        </act>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#clinNotes_Results_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20210125145624"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="AdvanceDirectives"/>
+                    <code code="42348-3" displayName="ADVANCE DIRECTIVES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Advance Directives</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Directive</th>
+                                    <th>Yes / No</th>
+                                    <th>Effective Date</th>
+                                    <th>File Name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownAdvanceDirective" xmlns="urn:hl7-org:v3"
+                                            >No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Encounters"/>
+                    <code code="46240-8" displayName="HISTORY OF ENCOUNTERS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Encounters</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Description</th>
+                                    <th>Practice</th>
+                                    <th>Location</th>
+                                    <th>Reason(s) For Visit</th>
+                                    <th>Diagnoses</th>
+                                    <th>Date</th>
+                                    <th>Provider</th>
+                                    <th>Providers Copied on Encounter</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                    <td>
+                                        <content>HoitzThisIsAReallyLongLa TerryThisIsAReallyLongFi.
+                                            1 Jarrett White Rd, Tripler Army Medical Center, HI,
+                                            968595000, US. tel:+1-8084331212</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_1" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>
+                                                <content>sore throat (chief complaint)</content>
+                                            </item>
+                                            <item>
+                                                <content>Sore throat (chief complaint)</content>
+                                            </item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Acute tonsillitis due to other specified
+                                                organisms</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension (chief complaint)</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Hypertension</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Fever - Finding</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="9d7d931c-948f-4a59-a532-d9b96c868129"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_0"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202109201436"/>
+                                <high value="202109201436"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                                        <city>Tripler Army Medical Center</city>
+                                        <state>HI</state>
+                                        <postalCode>96859-5000</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-8084331212"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>HoitzThisIsAReallyLongLa</family>
+                                            <given>TerryThisIsAReallyLongFi</given>
+                                            <given>TerrysMiddleName-35-</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id nullFlavor="UNK"/>
+                                            <code nullFlavor="UNK">
+                                                <translation nullFlavor="UNK"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"/>
+                            <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_1"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202003041348"/>
+                                <high value="202003041348"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200304"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_1"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="285533fa-4983-4e30-b718-c2942646ea36"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="J03.80"
+                                                displayName="Acute tonsillitis due to other specified organisms"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time nullFlavor="UNK"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202003041440-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="26db8415-1153-455c-a328-da1aeb35e30f"/>
+                            <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_2"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202002281351"/>
+                                <high value="202002281351"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200228"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_2"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="5ad6f921-233e-4d8c-927d-ecfd26bfbaf9"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20200228"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="I10" displayName="Hypertension"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20200228"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202002281406-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_3"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="201506221000"/>
+                                <high value="201506221000"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                            <code code="~" displayName="~"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation nullFlavor="NA"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20150622"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="R50.9" displayName="Fever - Finding"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20150622"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202103261221-0400"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom value="5555551002"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FamilyHistory"/>
+                    <code code="10157-6" displayName="HISTORY OF FAMILY MEMBER DISEASES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Family History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Family Member</th>
+                                    <th>Type</th>
+                                    <th>Diagnosis</th>
+                                    <th>Age At Onset</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_0"
+                                            xmlns="urn:hl7-org:v3">Alive and well</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_1"
+                                            xmlns="urn:hl7-org:v3">Family history of
+                                            asthma</content>
+                                    </td>
+                                    <td>
+                                        <content>16</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"
+                                extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <statusCode code="completed"/>
+                            <subject>
+                                <relatedSubject classCode="PRS">
+                                    <code code="BRO" displayName="Brother"
+                                        codeSystem="2.16.840.1.113883.5.111"
+                                        codeSystemName="HL7RoleCode"/>
+                                    <subject>
+                                        <sdtc:id root="1.3.6.1.4.1.21367.13.40.117"
+                                            extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"
+                                            xmlns:sdtc="urn:hl7-org:sdtc"/>
+                                        <name>Kenneth</name>
+                                        <administrativeGenderCode code="M" displayName="Male"
+                                            codeSystem="2.16.840.1.113883.5.1"
+                                            codeSystemName="HL7AdministrativeGender"/>
+                                        <birthTime nullFlavor="UNK"/>
+                                    </subject>
+                                </relatedSubject>
+                            </subject>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160445003" displayName="Alive and well"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_0"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="d1af37b2-178e-4cd9-ae47-3f63d9d6947f"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160377001" displayName="Family history of asthma"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_1"/>
+                                        </originalText>
+                                    </value>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.31"/>
+                                            <code code="445518008" displayName="Age At Onset"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT"/>
+                                            <statusCode code="completed"/>
+                                            <value value="16" unit="a" xsi:type="PQ"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Immunizations"/>
+                    <code code="11369-6" displayName="HISTORY OF IMMUNIZATION NARRATIVE"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Immunizations</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Vaccine</th>
+                                    <th>Date</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_0" xmlns="urn:hl7-org:v3"
+                                            >influenza, intradermal, quadrivalent, preservative
+                                            free, injectable</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>refused</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_0" xmlns="urn:hl7-org:v3"
+                                            >Note: Immunization was not given - Patient rejected
+                                            immunization. ; Source: New Immunization Record
+                                        </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_1" xmlns="urn:hl7-org:v3"
+                                            >diphtheria, tetanus toxoids and acellular pertussis
+                                            vaccine, 5 pertussis antigens</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-04-2012</content>
+                                    </td>
+                                    <td>
+                                        <content>administered</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_1" xmlns="urn:hl7-org:v3"
+                                            >Source: Source Unspecified </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="true">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="51f02998-93bb-4385-9050-873373b9fc44"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_0"/>
+                            </text>
+                            <statusCode code="aborted"/>
+                            <effectiveTime value="20150622"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="166"
+                                            displayName="influenza, intradermal, quadrivalent, preservative free, injectable"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_0"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK"/>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319185347"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706151004-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="ba7049e4-8bcb-4a44-84e8-9e3f40d28f5f"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20120104"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="106"
+                                            displayName="diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_1"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText>2</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319184655"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201705081257-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Payer"/>
+                    <code code="48768-6" displayName="PAYMENT SOURCES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Payers</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Payer name</th>
+                                    <th>Insurance type</th>
+                                    <th>Covered party ID</th>
+                                    <th>Authorization(s)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownPayer" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="SocialHistory"/>
+                    <code code="29762-2" displayName="SOCIAL HISTORY"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Social History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Description</th>
+                                    <th>Quantity</th>
+                                    <th>Date Captured</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_0" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_0"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_0"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_1" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_1"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_1"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_2" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Cigarette smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_2"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_3" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Current every day smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_3"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobacco_5"
+                                            xmlns="urn:hl7-org:v3">Smoking Tobacco Use
+                                            Details</content>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobaccoDate_5"
+                                            xmlns="urn:hl7-org:v3">Aug-17-2017</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_6" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_6"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_6"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_7" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_7"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_7"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_8" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_8"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_9" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_9"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_11" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_11"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_11"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_12"
+                                            xmlns="urn:hl7-org:v3">Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_12"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_12"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_13" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_13"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_14" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_14"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Birth Sex</content>
+                                    </td>
+                                    <td>
+                                        <content ID="BSex_value0" xmlns="urn:hl7-org:v3"
+                                            >Female</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_3"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20150622"/>
+                            <value code="449868002" displayName="Current every day smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_9"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200304"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_14"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200228"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_0"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_6"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_11"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe" extension="TobaccoUse"/>
+                            <code code="11367-0" displayName="History of tobacco use"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistoryTobacco_2"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value code="65568007" displayName="Cigarette smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_1"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_7"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_12"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="SmokingTobacco"/>
+                            <code code="229819007" displayName="Tobacco use and exposure"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistorySmokingTobacco_5"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20170817"/>
+                            </effectiveTime>
+                            <value xsi:type="ST">Cigarette: No Details Available Quantity Details -
+                                Cigarette: No Details Available </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708170737-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.200"
+                                extension="2016-06-01"/>
+                            <code code="76689-9" displayName="Sex Assigned At Birth"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#BSex_value0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1"
+                                codeSystemName="HL7AdministrativeGender" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BSex_value0"/>
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202104020755-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="VitalSigns"/>
+                    <code code="8716-3" displayName="VITAL SIGNS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Vital Signs</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date / Time:</th>
+                                    <th>Height</th>
+                                    <th>Weight</th>
+                                    <th>BMI</th>
+                                    <th>Pulse Rate</th>
+                                    <th>Blood Pressure</th>
+                                    <th>Temperature</th>
+                                    <th>Respiratory Rate</th>
+                                    <th>Body Surface Area</th>
+                                    <th>Head Circumference</th>
+                                    <th>Head Circ. Percentile</th>
+                                    <th>Wt./Len. Percentile</th>
+                                    <th>BMI percentile</th>
+                                    <th>Pulse Ox</th>
+                                    <th>Inhaled Ox</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015 10:05 AM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_0" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_0" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_0" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeartBeat_0" xmlns="urn:hl7-org:v3"
+                                            >80 /min</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_0"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_0" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsRespiratoryRate_0"
+                                            xmlns="urn:hl7-org:v3">18 /min</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsPulseOx_0" xmlns="urn:hl7-org:v3">95
+                                            %</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsInhaledOxyConc_0"
+                                            xmlns="urn:hl7-org:v3">36 %</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020 1:55 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_1" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_1" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_1" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_1"
+                                            xmlns="urn:hl7-org:v3">150/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_1" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020 1:59 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_2" xmlns="urn:hl7-org:v3"
+                                            >65.00 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_2" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (165.00 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_2" xmlns="urn:hl7-org:v3">27.46
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_2"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="201506221005-0400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201707271030-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_height_0"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_weight_0"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_systolic_0"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_diastolic_0"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="heart_rate_0"/>
+                                    <code code="8867-4" displayName="Heart Rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeartBeat_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="80" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_temperature_0"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="respiratory_rate_0"/>
+                                    <code code="9279-1" displayName="Respiratory rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsRespiratoryRate_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="18" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="sao2_%_blda_pulseox_0"/>
+                                    <code code="59408-5" displayName="SaO2 % BldA PulseOx"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsPulseOx_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="95" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="inhaled_oxygen_concentration_0"/>
+                                    <code code="3150-0" displayName="Inhaled Oxygen Concentration"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsInhaledOxyConc_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="36" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202003041355-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200304"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111850-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_height_1"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_weight_1"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_systolic_1"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="150" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_diastolic_1"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_temperature_1"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_mass_index_1"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202002281359-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174" extension="43"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281401-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_height_2"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_weight_2"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_systolic_2"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_diastolic_2"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_mass_index_2"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="27.46" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="ChiefComplaintAndReasonForVisit"/>
+                    <code code="46239-0" displayName="CHIEF COMPLAINT AND REASON FOR VISIT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Chief Complaint And Reason For Visit</title>
+                    <text>
+                        <paragraph>No Information</paragraph>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ReferralReason"/>
+                    <code code="42349-1" displayName="REASON FOR REFERRAL"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Reason For Referral</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Reason For Referral</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="1">
+                                        <content ID="UnknownReferral" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="PlanOfCare"/>
+                    <code code="18776-5" displayName="TREATMENT PLAN"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Plan Of Treatment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Action</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Radiology Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_0" xmlns="urn:hl7-org:v3">EKG
+                                            (93000), Scheduled for: Jun-23-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Lab Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_1" xmlns="urn:hl7-org:v3"
+                                            >Urinanalysis macro (dipstick) panel (81002), Scheduled
+                                            for: Jun-29-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="bdb795ab-6f6d-415e-956c-fb87940dd574"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#FutureOrder_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506230400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708151638-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="3f143484-5a7b-4aca-acab-1bf2f8539896"/>
+                            <code code="24357-6"
+                                displayName="Urinalysis macro (dipstick) panel - Urine"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#FutureOrder_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506291200"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201725-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HistoryOfPresentIllness"/>
+                    <code code="10164-2" displayName="HISTORY OF PRESENT ILLNESS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History Of Present Illness</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Date</th>
+                                    <th>Complaint</th>
+                                    <th>History Of Present Illness</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>The HTN started in 2015. The symptoms began
+                                            gradually. The severity has been described as being 6.
+                                            It is currently stable. Risk factors include inactive
+                                            lifestyle, obesity, sleep apnea and smoking. The
+                                            hypertension is exacerbated by anxiety. Associated
+                                            symptoms include fatigue and headache.</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FunctionalStatus"/>
+                    <code code="47420-5" displayName="Functional Status"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Functional Status</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Functional Assessment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>May-01-2005</content>
+                                    </td>
+                                    <td>
+                                        <content>Dependence on cane</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"
+                                extension="2014-06-09"/>
+                            <id nullFlavor="UNK"/>
+                            <code nullFlavor="NP"/>
+                            <statusCode code="completed"/>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"
+                                        extension="2014-06-09"/>
+                                    <id root="e942984a-f2fb-416e-80ce-d481c8b0fb71"/>
+                                    <code code="54522-8" displayName="Functional Status"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20050501"/>
+                                    <value code="105504002" displayName="Dependence on cane"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.128"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime nullFlavor="UNK"/>
+                                    <value nullFlavor="UNK" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CcdaMedicationsAdministered"/>
+                    <code code="29549-3" displayName="MEDICATION ADMINISTERED"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications Administered</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="UnknownMedicationAdministered"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Instructions"/>
+                    <code code="69730-0" displayName="INSTRUCTIONS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Instructions</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Instruction</th>
+                                    <th>Additional Information</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PatientInstruction_0" xmlns="urn:hl7-org:v3">i.
+                                            Get an EKG done on 6/23/2015. ii. Get a Chest X-ray done
+                                            on 6/23/2015 showing the Lower Respiratory Tract
+                                            Structure. iii. Take Clindamycin 300mg three times a day
+                                            as needed if pain does not subside. iv. Schedule follow
+                                            on visit with Neighborhood Physicians Practice on
+                                            7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Related to Fever - Finding</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act moodCode="INT" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="1d98f86c-5319-45d4-98fa-a26df91591dc"/>
+                            <code code="423564006" displayName="Provider Instructions for treatment"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+                            <text>
+                                <reference value="#PatientInstruction_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000"/>
+                            </effectiveTime>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Assessment"/>
+                    <code code="51848-0" displayName="ASSESSMENTS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Assessments</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Assessment</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Fever - Finding</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>impression</content>
+                                    </td>
+                                    <td>
+                                        <content>The patient was found to have fever and Dr Davis is
+                                            suspecting Anemia based on the patient history. So Dr
+                                            Davis asked the patient to closely monitor the
+                                            temperature and blood pressure and get admitted to
+                                            Community Health Hospitals if the fever does not subside
+                                            within a day. i. Get an EKG done on 6/23/2015. ii. Take
+                                            Clindamycin 300mg three times a day as needed if pain
+                                            does not subside. iii. Schedule follow on visit with
+                                            Neighborhood Physicians Practice on 7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Acute tonsillitis due to other specified
+                                            organisms</content>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.60"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Goals"/>
+                    <code code="61146-7" displayName="GOALS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Goals</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Goal</th>
+                                    <th>Type</th>
+                                    <th>Priority</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Fever</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_0" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occurring every few
+                                            weeks.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_1" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_2" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occuring every few
+                                            weeks</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_3" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="3b72c7a7-2b83-4e68-a1c9-bcc637fd389f"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occurring
+                                every few weeks.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="d2b8277e-2016-4489-b2db-34360fde0cd0"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="eff3999e-ad61-477c-864f-402b281924a3"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occuring
+                                every few weeks</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="41ccf5d4-05af-48f1-949d-659040b8a781"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="MedicalEquipment"/>
+                    <code code="46264-8" displayName="MEDICAL EQUIPMENT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medical Equipment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th>Device</th>
+                                    <th>Universal Device Identifier</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Device Status</th>
+                                    <th>Implantable Device Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ImplantableProcDev__0_0" xmlns="urn:hl7-org:v3"
+                                            >CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>(01)00643169007222(17)160128(21)BLC200461H</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.313"
+                                extension="2018-05-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code code="33216"
+                                displayName="Introduction of cardiac pacemaker system via vein"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"
+                                xsi:type="CE"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.310"
+                                        extension="2018-05-01"/>
+                                    <id root="2.16.840.1.113883.3.3719"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="FDA"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK">
+                                            <originalText>
+                                                <reference value="#ImplantableProcDev__0_0"/>
+                                            </originalText>
+                                        </code>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="2.16.840.1.113883.3.3719"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP">
+                                <organizer classCode="CLUSTER" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.311"
+                                        extension="2019-06-21"/>
+                                    <id extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        root="2.16.840.1.113883.3.3719"/>
+                                    <code code="74711-3" displayName="Unique Device Identifier"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.304"
+                                                extension="2019-06-21"/>
+                                            <code code="C101722" displayName="Primary DI Number"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value root="1.3.160" extension="00643169007222"
+                                                displayable="true" assigningAuthorityName="GS1"
+                                                xsi:type="II"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.318"
+                                                extension="2019-06-21"/>
+                                            <code code="C106044" displayName="MRI Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C113844"
+                                                displayName="Labeling does not contain MRI Safety Information"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.46"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.314"
+                                                extension="2019-06-21"/>
+                                            <code code="C160938" displayName="Latex Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C106038"
+                                                displayName="Not Made with Natural Rubber Latex"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.47"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.305"
+                                                extension="2019-06-21"/>
+                                            <code code="C160939"
+                                                displayName="Implantable Device Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C45329" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.48"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.306"
+                                                extension="2018-05-01"/>
+                                            <code code="UDI-00007" displayName="Device Status"
+                                                codeSystem="1.3.6.1.4.1.19376.1.4.1.6.5.290"
+                                                codeSystemName="UDI Observation Type"/>
+                                            <value code="active"
+                                                codeSystem="2.16.840.1.113883.4.642.3.199"
+                                                codeSystemName="Device Status" xsi:type="CD"/>
+                                        </observation>
+                                    </component>
+                                </organizer>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HealthConcerns"/>
+                    <code code="75310-3" displayName="HEALTH CONCERNS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Observation</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthStatusObs_0" xmlns="urn:hl7-org:v3"
+                                            >Chronically ill</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Concern</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_0" xmlns="urn:hl7-org:v3"
+                                            >Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_1" xmlns="urn:hl7-org:v3"
+                                            >Weight - 88.000 kg</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_2" xmlns="urn:hl7-org:v3"
+                                            >Fever - Finding - R50.9</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_3" xmlns="urn:hl7-org:v3">BMI
+                                            - 28.08 - Watch weight of patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_4" xmlns="urn:hl7-org:v3"
+                                            >Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_5" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_6" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_7" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_8" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="EVN" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5" extension="2014-06-09"/>
+                            <id root="45cf87bf-0952-4e7c-b049-ad19b435729e"/>
+                            <code code="11323-3" displayName="HEALTH STATUS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthStatusObs_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="161901003" displayName="Chronically ill"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111912-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c7dcddd1-8a45-4536-8975-9df72a77d474"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6c1d5761-3b89-4592-97ac-67905ef3e3d8"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="a30988e2-aab4-4ff7-8ac8-a286393f22fb"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061059-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_4"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061100-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="5214ea51-a323-4a9e-860d-7b8f688688cd"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_5"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="deda0b49-2996-411b-b9b9-e517db9bec04"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_6"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061057-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c5bb9c90-1562-42b4-a2c1-fcf7868443e5"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_7"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_8"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061058-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.500" extension="2019-07-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CareTeam"/>
+                    <code code="85847-2" displayName="PATIENT CARE TEAM"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Patient Care Teams</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Members</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_0" xmlns="urn:hl7-org:v3">Core
+                                            Team</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>nullified</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item> Kristin Allison.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_1" xmlns="urn:hl7-org:v3">Care Team
+                                            A</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>[Family medicine specialist] Albert Davis, 2472
+                                                Rocky Place, Beaverton, OR, 97006.</item>
+                                            <item>[grandfather] Rick Holler, 1357 Amber Dr,
+                                                Beaverton, OR, 97006.</item>
+                                            <item>[spouse] Matthew Newman, 1357 Amber Dr.,
+                                                Beaverton, OR, 97006.</item>
+                                            <item> Tracy Davis, 2472 Rocky Place, Beaverton, OR,
+                                                97006.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="5ae3655e-dfe0-4bf9-9ec3-b3693d6956f5"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_0"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="nullified"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101291121-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="9a7b1756-d0a6-4db9-93f9-260dbaa04dc7"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode nullFlavor="UNK"/>
+                                    <effectiveTime>
+                                        <low nullFlavor="UNK"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low nullFlavor="UNK"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id root="2.16.840.1.113883.4.6" extension="1528951720"/>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Allison</family>
+                                                  <given>Kristin</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="1755af9d-4c9f-4442-ac10-fc9d2b264338"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_1"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101191649-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="6ebb65ef-0d6f-4358-87da-96e4b71f8b4b"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="207Q00000X"
+                                                displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Neighborhood Physicians Practice</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="48563921-dded-4fc5-b54e-0b86775d7fca"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Holler</family>
+                                                  <given>Rick</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="335b6602-a8b2-4d3d-8744-9ad850e7ebc6"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Newman</family>
+                                                  <given>Matthew</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="b72378a1-6e51-4e33-a209-93374a095f12"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="251B00000X"
+                                                displayName="Agencies : Case Management"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Tracy</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="DischargeSummaryClinicalNotes"/>
+                    <code code="18842-5" displayName="Discharge summary"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Discharge Summary Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownDischargeSummaryClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="18842-5" displayName="Discharge summary"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownDischargeSummaryClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ConsultNoteClinicalNotes"/>
+                    <code code="11488-4" displayName="Consult Note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Consultation Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownConsultNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11488-4" displayName="Consult Note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownConsultNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="HistoryPhysicalNoteClinicalNotes"/>
+                    <code code="34117-2" displayName="History and physical note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History and Physical Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownHistoryPhysicalNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="34117-2" displayName="History and physical note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownHistoryPhysicalNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ProgressNoteNoteClinicalNotes"/>
+                    <code code="11506-3" displayName="Progress note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Progress Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_ProgressNoteNoteClinicalNotes_0"
+                                            xmlns="urn:hl7-org:v3">Ms Alice Newman seems to be
+                                            developing high fever and hence we recommend her to get
+                                            admitted to a nearby hospital using the provided
+                                            referral. </content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                        	<!--  Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11506-3" displayName="Progress note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_ProgressNoteNoteClinicalNotes_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210920"/>
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 invalid TS as per provenance reqs, but is not provenance, so should not be content validation error
+                                 -->
+                                <time value="20210920144244"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                            	<!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- Valid time and should NOT produce error (has time-zone) -->                                    
+                                <time value="202109201442-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="9d7d931c-948f-4a59-a532-d9b96c868129"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/src/test/resources/cures/sub/SUB_VALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
+++ b/src/test/resources/cures/sub/SUB_VALID_PROVENANCE_TS_VALID_AUTHOR_PARTICIPATION_TS_SITE_3331.xml
@@ -1,0 +1,10362 @@
+<?xml version="1.0"?><?xml-stylesheet type='text/xsl' href='http://www.nextgenshare.com/public/CDA_NGMU2.xsl'?>
+<ClinicalDocument xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc"
+    xmlns="urn:hl7-org:v3" xmlns:mif="urn:hl7-org:v3/mif"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <realmCode code="US"/>
+    <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2"/>
+    <templateId root="2.16.840.1.113883.10.20.22.1.2" extension="2015-08-01"/>
+    <id root="1.3.6.1.4.1.21367.13.40.117" extension="f0b0de8a-dfd1-458b-99a5-523011eba40b"/>
+    <code code="34133-9" displayName="SUMMARIZATION OF EPISODE NOTE"
+        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+    <title>Continuity of Care Document (C-CDA R2.1)</title>
+    <effectiveTime value="20210920164540-0400"/>
+    <confidentialityCode code="N" displayName="Normal Sharing" codeSystem="2.16.840.1.113883.5.25"
+        codeSystemName="HL7 Confidentiality"/>
+    <languageCode code="en-US"/>
+    <recordTarget>
+        <patientRole>
+            <id extension="8658" root="1.100"/>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom use="MC" value="tel:+1-5557771234"/>
+            <telecom use="HP" value="tel:+1-5557231544"/>
+            <telecom value="mailto:sadavis@nextgen.com"/>
+            <patient>
+                <name use="L">
+                    <family>Newman</family>
+                    <given qualifier="CL">Alice</given>
+                    <given>Jones</given>
+                </name>
+                <name use="SRCH">
+                    <family>Newman</family>
+                    <given qualifier="BR">Alicia</given>
+                </name>
+                <administrativeGenderCode code="F" displayName="Female"
+                    codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
+                <birthTime value="19700501"/>
+                <raceCode code="2106-3" displayName="White" codeSystem="2.16.840.1.113883.6.238"
+                    codeSystemName="CDC Race and Ethnicitys"/>
+                <sdtc:raceCode code="2108-9" displayName="European"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity"/>
+                <ethnicGroupCode code="2186-5" displayName="Not Hispanic or Latino"
+                    codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicitys"/>
+                <languageCommunication>
+                    <templateId root="2.16.840.1.113883.3.88.11.32.2"/>
+                    <languageCode code="en"/>
+                    <preferenceInd value="true"/>
+                </languageCommunication>
+            </patient>
+            <providerOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </providerOrganization>
+        </patientRole>
+    </recordTarget>
+    <author>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id root="1.174" extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+        </assignedAuthor>
+    </author>
+    <author>
+        <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
+        <time value="20210920164540-0400"/>
+        <assignedAuthor>
+            <id nullFlavor="UNK"/>
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom value="5555551002"/>
+            <assignedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom value="5555551002"/>
+            </representedOrganization>
+        </assignedAuthor>
+    </author>
+    <informant>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <family>Admin</family>
+                    <given>NEXTGEN</given>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </informant>
+    <custodian>
+        <assignedCustodian>
+            <representedCustodianOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedCustodianOrganization>
+        </assignedCustodian>
+    </custodian>
+    <legalAuthenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom use="WP" nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </legalAuthenticator>
+    <authenticator>
+        <time value="20210920164540-0400"/>
+        <signatureCode code="S"/>
+        <assignedEntity>
+            <id root="1.174" extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+            <addr nullFlavor="UNK"/>
+            <telecom nullFlavor="UNK"/>
+            <assignedPerson>
+                <name>
+                    <given>NEXTGEN</given>
+                    <family>Admin</family>
+                </name>
+            </assignedPerson>
+            <representedOrganization>
+                <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                <name>Neighborhood Physicians Practice</name>
+                <telecom use="WP" value="tel:+1-5555551002"/>
+                <addr>
+                    <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                    <city>Beaverton</city>
+                    <state>OR</state>
+                    <postalCode>97006</postalCode>
+                    <country>US</country>
+                </addr>
+            </representedOrganization>
+        </assignedEntity>
+    </authenticator>
+    <participant typeCode="IND">
+        <time value="19400101"/>
+        <associatedEntity classCode="PRS">
+            <code code="GRPRN" displayName="grandparent" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="04" displayName="Grandparent"
+                    codeSystem="2.16.840.1.113883.3.109" codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Holler</family>
+                    <given>Rick</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <time value="19790101"/>
+        <associatedEntity classCode="PRS">
+            <code code="SPS" displayName="spouse" codeSystem="2.16.840.1.113883.5.111"
+                codeSystemName="HL7RoleCode">
+                <translation code="01" displayName="Spouse" codeSystem="2.16.840.1.113883.3.109"
+                    codeSystemName="NextGen Coding System"/>
+            </code>
+            <addr>
+                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+                <country>US</country>
+            </addr>
+            <telecom nullFlavor="UNK"/>
+            <associatedPerson>
+                <name>
+                    <family>Newman</family>
+                    <given>Matthew</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <associatedEntity classCode="CAREGIVER">
+            <addr>
+                <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                <city>Beaverton</city>
+                <state>OR</state>
+                <postalCode>97006</postalCode>
+            </addr>
+            <telecom use="HP" value="tel:+1-5555551002"/>
+            <associatedPerson>
+                <name>
+                    <family>Allison</family>
+                    <given>Kristin</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <participant typeCode="IND">
+        <functionCode code="PCP" codeSystem="2.16.840.1.113883.5.88"/>
+        <associatedEntity classCode="CAREGIVER">
+            <associatedPerson>
+                <name>
+                    <family>Davis</family>
+                    <given>Albert</given>
+                </name>
+            </associatedPerson>
+        </associatedEntity>
+    </participant>
+    <documentationOf typeCode="DOC">
+        <serviceEvent classCode="PCPR">
+            <effectiveTime>
+                <low value="201506221000"/>
+                <high value="202109201436"/>
+            </effectiveTime>
+            <performer typeCode="PRF">
+                <time>
+                    <low value="202109201645"/>
+                    <high value="202109201645"/>
+                </time>
+                <assignedEntity>
+                    <id root="1.174" extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"/>
+                    <addr>
+                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                        <city>Tripler Army Medical Center</city>
+                        <state>HI</state>
+                        <postalCode>96859-5000</postalCode>
+                        <country>US</country>
+                    </addr>
+                    <telecom nullFlavor="UNK"/>
+                    <assignedPerson>
+                        <name>
+                            <given>TerryThisIsAReallyLongFi</given>
+                            <family>HoitzThisIsAReallyLongLa</family>
+                        </name>
+                    </assignedPerson>
+                </assignedEntity>
+            </performer>
+        </serviceEvent>
+    </documentationOf>
+    <component>
+        <structuredBody>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1" extension="2015-08-01"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.6.1"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Alerts"/>
+                    <code code="48765-2" displayName="Allergies and adverse reactions Document"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Allergies, Adverse Reactions, Alerts</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Substance</th>
+                                    <th>Reaction</th>
+                                    <th>Status</th>
+                                    <th>Criticality</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_0" xmlns="urn:hl7-org:v3"
+                                            >penicillin G </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_0_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_0_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_0" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_0" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="AllergyDescription_1" xmlns="urn:hl7-org:v3"
+                                            >ampicillin </content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item xmlns="urn:hl7-org:v3"><content
+                                                  ID="Allergy_1_Reaction_0" xmlns="urn:hl7-org:v3"
+                                                  >Hives</content> (<content
+                                                  ID="Allergy_1_Reaction_0_Severity"
+                                                  xmlns="urn:hl7-org:v3">moderate</content>)</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyStatus_1" xmlns="urn:hl7-org:v3"
+                                            >Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="AllergyCriticality_1" xmlns="urn:hl7-org:v3"
+                                            >Low</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="fbda38da-e283-4dfb-b11f-3f0413947af2"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201810241352-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Canonica</family>
+                                                  <given>Gina</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="7980" displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_0"/>
+                                                  </originalText>
+                                                  <translation code="4977"
+                                                  displayName="penicillin G"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>penicillin G</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_0_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_0_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_0_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.30"
+                                extension="2015-08-01"/>
+                            <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"
+                                codeSystemName="HL7ActClass"/>
+                            <text>
+                                <reference value="#AllergyDescription_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="19800510"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="19800510"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.7"
+                                        extension="2014-06-09"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"/>
+                                    <templateId root="2.16.840.1.113883.10.20.24.3.90"
+                                        extension="2014-06-09"/>
+                                    <id root="e8af4552-347e-4b63-a8d8-d5a096eeb418"/>
+                                    <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4"
+                                        codeSystemName="HL7ActCode"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="19800510"/>
+                                    </effectiveTime>
+                                    <value code="416098002" displayName="drug allergy"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="19800510"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101121613-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <participant typeCode="CSM">
+                                        <participantRole classCode="MANU">
+                                            <playingEntity classCode="MMAT">
+                                                <code code="733" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.6.88"
+                                                  codeSystemName="RxNorm">
+                                                  <originalText>
+                                                  <reference value="#AllergyDescription_1"/>
+                                                  </originalText>
+                                                  <translation code="2692" displayName="ampicillin"
+                                                  codeSystem="2.16.840.1.113883.4.65"
+                                                  codeSystemName="FDB Hierarchical Ingredient Code Sequence Number (HIC_SEQN)"
+                                                  />
+                                                </code>
+                                                <name>ampicillin</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                    <entryRelationship typeCode="MFST" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.9"
+                                                extension="2014-06-09"/>
+                                            <id root="be01051c-57e1-40de-b225-51ee1094287a"/>
+                                            <code code="ASSERTION"
+                                                codeSystem="2.16.840.1.113883.5.4"
+                                                codeSystemName="HL7ActCode"/>
+                                            <text>
+                                                <reference value="#Allergy_1_Reaction_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="19800510"/>
+                                            </effectiveTime>
+                                            <value code="247472004" displayName="Hives"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD">
+                                                <originalText>
+                                                  <reference value="#Allergy_1_Reaction_0"/>
+                                                </originalText>
+                                            </value>
+                                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                                <observation classCode="OBS" moodCode="EVN">
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"/>
+                                                  <templateId root="2.16.840.1.113883.10.20.22.4.8"
+                                                  extension="2014-06-09"/>
+                                                  <code code="SEV" displayName="Severity"
+                                                  codeSystem="2.16.840.1.113883.5.4"
+                                                  codeSystemName="HL7ActCode" xsi:type="CE"/>
+                                                  <text>
+                                                  <reference value="#Allergy_1_Reaction_0_Severity"
+                                                  />
+                                                  </text>
+                                                  <statusCode code="completed"/>
+                                                  <value code="6736007" displayName="moderate"
+                                                  codeSystem="2.16.840.1.113883.6.96"
+                                                  codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                                </observation>
+                                            </entryRelationship>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.145"/>
+                                            <code code="82606-5" displayName="Criticality"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyCriticality_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="CRITL" displayName="Low"
+                                                codeSystem="2.16.840.1.113883.5.1063"
+                                                codeSystemName="HL7SeverityObservation"
+                                                xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.28"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#AllergyStatus_1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CE"/>
+                                        </observation>
+                                    </entryRelationship>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.1.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Medications"/>
+                    <code code="10160-0" displayName="History of Medication use Narrative"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_0" xmlns="urn:hl7-org:v3"
+                                            >Aranesp 500 mcg/mL (in polysorbate) injection
+                                            syringe</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_0" xmlns="urn:hl7-org:v3">inject
+                                            1 milliliter by subcutaneous route every week</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_0" xmlns="urn:hl7-org:v3">2.25
+                                            MCG/KG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_1" xmlns="urn:hl7-org:v3"
+                                            >clindamycin 300 mg capsule</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_1" xmlns="urn:hl7-org:v3">take 1
+                                            capsule by oral route 3 times every day if pain does not
+                                            subside as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_1" xmlns="urn:hl7-org:v3">300
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-01-2017 - Oct-30-2018</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_2" xmlns="urn:hl7-org:v3"
+                                            >Tylenol Extra Strength 500 mg tablet</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_2" xmlns="urn:hl7-org:v3">take 1
+                                            tablet by oral route every 4 hours as needed</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_2" xmlns="urn:hl7-org:v3">500
+                                            MG</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jul-01-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_2" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="MedicationName_3" xmlns="urn:hl7-org:v3"
+                                            >ceftriaxone 100 gram solution for injection</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationSig_3" xmlns="urn:hl7-org:v3">inject
+                                            10 milligram by injection route 2 times every
+                                            day</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationDosage_3" xmlns="urn:hl7-org:v3">10
+                                            milligram</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - Jun-30-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>No Longer Active</content>
+                                    </td>
+                                    <td>
+                                        <content ID="MedicationComment_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="5418eadb-2b53-4aa6-9875-2f918456f0fa"/>
+                            <text>
+                                <reference value="#MedicationSig_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="1" unit="wk"/>
+                            </effectiveTime>
+                            <routeCode code="C38299" displayName="SUBCUTANEOUS"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="mL"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="731241"
+                                            displayName="1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe [Aranesp]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_0"/>
+                                            </originalText>
+                                            <translation code="55513003201"
+                                                displayName="darbepoetin alfa in polysorbat"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>1 ML darbepoetin alfa 0.5 MG/ML Prefilled Syringe
+                                            [Aranesp]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706142020-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="ddd500c2-4399-4a50-addd-aa2c26fa3fdf"/>
+                            <text>
+                                <reference value="#MedicationSig_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20170901"/>
+                                <high value="20181030"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="true" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="8" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{capsule}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="748748"
+                                            displayName="clindamycin 300 MG Oral Capsule [Cleocin]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_1"/>
+                                            </originalText>
+                                            <translation code="00527138301"
+                                                displayName="clindamycin HCl"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>clindamycin 300 MG Oral Capsule [Cleocin]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170901"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201810241401-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="6936cfb5-ad96-457e-8a90-1d71fd7e71f9"/>
+                            <text>
+                                <reference value="#MedicationSig_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150701"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="4" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38288" displayName="ORAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="1" unit="{tablet}"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="209459"
+                                            displayName="acetaminophen 500 MG Oral Tablet [Tylenol]"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_2"/>
+                                            </originalText>
+                                            <translation code="00450044406"
+                                                displayName="acetaminophen"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                        <name>acetaminophen 500 MG Oral Tablet [Tylenol]</name>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101141402-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="INT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                                extension="2014-06-09"/>
+                            <id root="f6552a8d-5ae6-42ce-a4a8-e86bcba51a7d"/>
+                            <text>
+                                <reference value="#MedicationSig_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime xsi:type="IVL_TS">
+                                <low value="20150622"/>
+                                <high value="20150630"/>
+                            </effectiveTime>
+                            <effectiveTime institutionSpecified="false" operator="A"
+                                xsi:type="PIVL_TS">
+                                <period value="12" unit="h"/>
+                            </effectiveTime>
+                            <routeCode code="C38291" displayName="PARENTERAL"
+                                codeSystem="2.16.840.1.113883.3.26.1.1" codeSystemName="NCI"/>
+                            <doseQuantity value="10" unit="mg"/>
+                            <consumable>
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="309090"
+                                            displayName="ceftriaxone 100 MG/ML Injectable Solution"
+                                            codeSystem="2.16.840.1.113883.6.88"
+                                            codeSystemName="RxNorm">
+                                            <originalText>
+                                                <reference value="#MedicationName_3"/>
+                                            </originalText>
+                                            <translation code="66288610001"
+                                                displayName="ceftriaxone sodium"
+                                                codeSystem="2.16.840.1.113883.6.69"
+                                                codeSystemName="NDC"/>
+                                        </code>
+                                    </manufacturedMaterial>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201554-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <informant>
+                                <assignedEntity>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </informant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                <act classCode="ACT" moodCode="INT">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                        extension="2014-06-09"/>
+                                    <code code="311401005" displayName="Patient Education"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <text>
+                                        <reference value="#MedicationSig_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.5.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Problems"/>
+                    <code code="11450-4" displayName="PROBLEM LIST"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Problems</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Condition</th>
+                                    <th>Type</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Clinical Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems0"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Chronic rejection of renal
+                                            transplant</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems1"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems2"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - </content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems3"
+                                            xmlns="urn:hl7-org:v3">Active (qualifier
+                                            value)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProblemName_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Overweight</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006 - Jun-01-2007</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ProblemStatus_PatientProblems4"
+                                            xmlns="urn:hl7-org:v3">Problem resolved
+                                            (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="dc419944-c4a3-4343-9782-7c3468b5be90"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="386661006" displayName="Fever"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202102081114-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="770ff05e-9f26-4245-a4e6-48c88b7a8a6e"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="236578006"
+                                        displayName="Chronic rejection of renal transplant"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems1"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20111005"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="59621000" displayName="Essential hypertension"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20111005"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201703191811-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Murphy</family>
+                                                  <given>Meghan</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems2"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <value code="83986005" displayName="Severe hypothyroidism"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101191712-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems3"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="55561003"
+                                                displayName="Active (qualifier value)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <code code="CONC" codeSystem="2.16.840.1.113883.5.6"/>
+                            <text>
+                                <reference value="#ProblemName_PatientProblems4"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20061231"/>
+                                <high value="20070601"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20061231"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                        extension="2015-08-01"/>
+                                    <id root="cb229847-35f2-4d70-bc2d-b3713e82763d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75326-9" displayName="Problem"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <text>
+                                        <reference value="#ProblemName_PatientProblems4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime>
+                                        <low value="20061231"/>
+                                        <high value="20070601"/>
+                                    </effectiveTime>
+                                    <value code="238131007" displayName="Overweight"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20061231"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201705081255-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="REFR" inversionInd="false">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.6"
+                                                extension="2019-06-20"/>
+                                            <code code="33999-4" displayName="STATUS"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ProblemStatus_PatientProblems4"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                            <value code="413322009"
+                                                displayName="Problem resolved (finding)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+					<!-- Procedures Section -->
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Procedures"/>
+                    <code code="47519-4" displayName="HISTORY OF PROCEDURES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Procedures</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure</th>
+                                    <th>Universal Device Identifier/Device Identifier</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_0" xmlns="urn:hl7-org:v3"
+                                            >Nebulizer Therapy</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_1" xmlns="urn:hl7-org:v3"
+                                            >Introduction of cardiac pacemaker system via
+                                            vein</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4 -
+                                                (01)00643169007222(17)160128(21)BLC200461H</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ProcedureDescription_3" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Procedure Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_Procedures_0" xmlns="urn:hl7-org:v3"
+                                            >Dr Albert Davis examined Ms Alice Newman and found that
+                                            the pacemaker is operating properly and the
+                                            breathlessness is due to high fever and
+                                            anxiety.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="aaff7f65-82dc-4039-85ac-5db62a9d983e"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_0"/>
+                                </originalText>
+                                <translation code="94640" displayName="Nebulizer Therapy"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high value="20150622"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101112008-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_1"/>
+                                </originalText>
+                                <translation code="33216"
+                                    displayName="Introduction of cardiac pacemaker system via vein"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20111005"/>
+                                <high value="20111005"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.37"/>
+                                    <id root="1.3.160"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="GS1"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK"/>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="1.3.160"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="ff884e65-94e1-4e11-9438-74b67d03da41"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_2"/>
+                                </originalText>
+                                <translation code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                                <high value="20200304"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041448-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="07250fe9-b4ac-485f-b42d-3dff1df1ddd8"/>
+                            <code nullFlavor="OTH" codeSystem="2.16.840.1.113883.6.96">
+                                <originalText>
+                                    <reference value="#ProcedureDescription_3"/>
+                                </originalText>
+                                <translation code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                    codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                                <high value="20200228"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281407-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                        codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"/>
+                                </encounter>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+							<!-- Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+								<!-- relevant identifying code 28570-0 in error -->
+                                <translation code="28570-0" displayName="Procedure note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_Procedures_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+								<!-- Author Participation (original) = 4.119 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+								<!-- -dbTest 1 - update to be valid as per provenance reqs (add time-zone) (even though not provenance) -->
+                                <time value="202101251456-0500"/> <!-- this time should no longer show up in 'provenance' error (or any content error) -->
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+								<!-- Provenance Provenance - Author Participation = 5.6 -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+								<!-- valid -->
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.3.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Results"/>
+                    <code code="30954-2"
+                        displayName="Relevant diagnostic tests &amp;or laboratory data"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Results</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Test Name</th>
+                                    <th>Date and Time</th>
+                                    <th>Measure</th>
+                                    <th>Units</th>
+                                    <th>Reference Range</th>
+                                    <th>Abnormal Flag</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_0" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Urinanalysis macro (dipstick)
+                                            panel</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_0" xmlns="urn:hl7-org:v3"
+                                            >SPECIMEN: source: Urine specimen, Urine</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_0" xmlns="urn:hl7-org:v3"
+                                            >Color of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_0"
+                                            xmlns="urn:hl7-org:v3">YELLOW</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_0" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_1" xmlns="urn:hl7-org:v3"
+                                            >Appearance of Urine</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_1"
+                                            xmlns="urn:hl7-org:v3">CLEAR</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_1" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_2" xmlns="urn:hl7-org:v3"
+                                            >Specific gravity of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>1.015</content>
+                                    </td>
+                                    <td>
+                                        <content>1</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_2"
+                                            xmlns="urn:hl7-org:v3">1.005-1.030</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_2" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_3" xmlns="urn:hl7-org:v3"
+                                            >pH of Urine by Test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>5.0</content>
+                                    </td>
+                                    <td>
+                                        <content>pH</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_3"
+                                            xmlns="urn:hl7-org:v3">5.0-8.0</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_3" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_4" xmlns="urn:hl7-org:v3"
+                                            >Glucose [Mass/volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>50</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_4"
+                                            xmlns="urn:hl7-org:v3">Neg</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_4" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_5" xmlns="urn:hl7-org:v3"
+                                            >Ketones [Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_5"
+                                            xmlns="urn:hl7-org:v3">Negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_5" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_0_6" xmlns="urn:hl7-org:v3"
+                                            >Protein[Mass/Volume] in urine by test strip</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 11:00:00</content>
+                                    </td>
+                                    <td>
+                                        <content>100</content>
+                                    </td>
+                                    <td>
+                                        <content>mg/dL</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_0_6"
+                                            xmlns="urn:hl7-org:v3">negative</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_0_6" xmlns="urn:hl7-org:v3"
+                                            >Performed by: Value Labs (2.16.840.1.113883.19) 2474
+                                            Rocky place Beaverton, OR 97006 </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="PanelName_1" xmlns="urn:hl7-org:v3">Panel
+                                            Description: Chest X-ray 2 views</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PanelComment_1" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="ResultDescription_1_0" xmlns="urn:hl7-org:v3"
+                                            >Chest X-ray 2 Views</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 21:54:00</content>
+                                    </td>
+                                    <td>
+                                        <content>Abnormal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultReferenceRange_1_0"
+                                            xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>A</content>
+                                    </td>
+                                    <td>
+                                        <content>Final</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ResultComment_1_0" xmlns="urn:hl7-org:v3">Lungs
+                                            are not clear, cannot rule out Anemia. Other tests are
+                                            required to determine the presence or absence of Anemia.
+                                        </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note Type</th>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Laboratory Report Narrative</content>
+                                    </td>
+                                    <td>
+                                        <content ID="clinNotes_Results_0" xmlns="urn:hl7-org:v3">Ms
+                                            Alice Newman was tested for the Urinanalysis macro panel
+                                            and the results have been found to be normal.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-25-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="f05926e4-90b4-4d39-b7db-46c5ae2c28bf"/>
+                            <code code="24357-6" displayName="Urinanalysis macro (dipstick) panel"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_0"/>
+                                </originalText>
+                                <translation code="81002"
+                                    displayName="Urinalysis, non-automated, w/scope"
+                                    codeSystemName="L"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000-0400"/>
+                                <high value="20150622110000-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622110000"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706301717-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Interface</family>
+                                            <given>Rosetta</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5778-6" displayName="Color of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">YELLOW</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>YELLOW</text>
+                                            <value xsi:type="ST">YELLOW</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5767-9" displayName="Appearance of Urine"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">CLEAR</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>CLEAR</text>
+                                            <value xsi:type="ST">CLEAR</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5811-5"
+                                        displayName="Specific gravity of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="1.015" unit="1"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>1.005-1.030</text>
+                                            <value xsi:type="ST">1.005-1.030</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5803-2" displayName="pH of Urine by Test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_3"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="5.0" unit="[pH]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>5.0-8.0</text>
+                                            <value xsi:type="ST">5.0-8.0</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5792-7"
+                                        displayName="Glucose [Mass/volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_4"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="50" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Neg</text>
+                                            <value xsi:type="ST">Neg</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5797-6"
+                                        displayName="Ketones [Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_5"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="ST">Negative</value>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>Negative</text>
+                                            <value xsi:type="ST">Negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="5804-0"
+                                        displayName="Protein[Mass/Volume] in urine by test strip"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_0_6"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622110000-0400"/>
+                                    <value xsi:type="PQ" value="100" unit="mg/dL"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622110000"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706301717-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Interface</family>
+                                                  <given>Rosetta</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <referenceRange>
+                                        <observationRange>
+                                            <text>negative</text>
+                                            <value xsi:type="ST">negative</value>
+                                        </observationRange>
+                                    </referenceRange>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="BATTERY" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.1" extension="2015-08-01"/>
+                            <id root="5f09fddb-1a80-4a65-8d24-8a2a08637f09"/>
+                            <code code="36643-5" displayName="Chest X-ray 2 views"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                xsi:type="CE">
+                                <originalText>
+                                    <reference value="#PanelName_1"/>
+                                </originalText>
+                                <translation code="71010" displayName="Chest X-ray"
+                                    codeSystemName="R"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622115900-0400"/>
+                                <high value="20150622115900-0400"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622115900"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706281613-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.2"
+                                        extension="2015-08-01"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code code="36643-5" displayName="Chest X-ray 2 Views"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <text>
+                                        <reference value="#ResultDescription_1_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20150622215400-0400"/>
+                                    <value xsi:type="ST">Abnormal</value>
+                                    <interpretationCode code="A" displayName="Abnormal"
+                                        codeSystem="2.16.840.1.113883.5.83"
+                                        codeSystemName="HL7 Observation Interpretation"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                        <time value="20150622115900"/>
+                                        <assignedAuthor>
+                                            <id root="1.174"
+                                                extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom use="WP" value="tel:+1-5555551002"/>
+                                                <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                </addr>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201706281613-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>User</family>
+                                                  <given>Adam</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <act classCode="ACT" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                            <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                                codeSystem="2.16.840.1.113883.6.1"
+                                                codeSystemName="LOINC"/>
+                                            <text>
+                                                <reference value="#ResultComment_1_0"/>
+                                            </text>
+                                            <statusCode code="completed"/>
+                                        </act>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#clinNotes_Results_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210125"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20210125145624"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101251456-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.21" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="AdvanceDirectives"/>
+                    <code code="42348-3" displayName="ADVANCE DIRECTIVES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Advance Directives</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Directive</th>
+                                    <th>Yes / No</th>
+                                    <th>Effective Date</th>
+                                    <th>File Name</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownAdvanceDirective" xmlns="urn:hl7-org:v3"
+                                            >No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Encounters"/>
+                    <code code="46240-8" displayName="HISTORY OF ENCOUNTERS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Encounters</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Description</th>
+                                    <th>Practice</th>
+                                    <th>Location</th>
+                                    <th>Reason(s) For Visit</th>
+                                    <th>Diagnoses</th>
+                                    <th>Date</th>
+                                    <th>Provider</th>
+                                    <th>Providers Copied on Encounter</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_0" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                    <td>
+                                        <content>HoitzThisIsAReallyLongLa TerryThisIsAReallyLongFi.
+                                            1 Jarrett White Rd, Tripler Army Medical Center, HI,
+                                            968595000, US. tel:+1-8084331212</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_1" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>
+                                                <content>sore throat (chief complaint)</content>
+                                            </item>
+                                            <item>
+                                                <content>Sore throat (chief complaint)</content>
+                                            </item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Acute tonsillitis due to other specified
+                                                organisms</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_2" xmlns="urn:hl7-org:v3"
+                                            >OFFICE/OUTPATIENT VISIT, EST</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension (chief complaint)</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Hypertension</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Encounter_3" xmlns="urn:hl7-org:v3"/>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice, 2472 Rocky Place,
+                                            Beaverton, OR, 97006, US tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content>Neighborhood Physicians Practice</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>Fever - Finding</item>
+                                        </list>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Davis Albert. 2472 Rocky Place, C/O Tracy Davis,
+                                            Beaverton, OR, 97006, US. tel:+1-5555551002</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="9d7d931c-948f-4a59-a532-d9b96c868129"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_0"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202109201436"/>
+                                <high value="202109201436"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="b0f57c0d-37e7-4d57-9d3a-84e20c0fdbae"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>1 Jarrett White Rd</streetAddressLine>
+                                        <city>Tripler Army Medical Center</city>
+                                        <state>HI</state>
+                                        <postalCode>96859-5000</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-8084331212"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>HoitzThisIsAReallyLongLa</family>
+                                            <given>TerryThisIsAReallyLongFi</given>
+                                            <given>TerrysMiddleName-35-</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id nullFlavor="UNK"/>
+                                            <code nullFlavor="UNK">
+                                                <translation nullFlavor="UNK"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value nullFlavor="UNK" xsi:type="CD"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"/>
+                            <code code="99211" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_1"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202003041348"/>
+                                <high value="202003041348"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200304"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_1"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="285533fa-4983-4e30-b718-c2942646ea36"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low nullFlavor="UNK"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="J03.80"
+                                                displayName="Acute tonsillitis due to other specified organisms"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time nullFlavor="UNK"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202003041440-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="26db8415-1153-455c-a328-da1aeb35e30f"/>
+                            <code code="99212" displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4">
+                                <originalText>
+                                    <reference value="#Encounter_2"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_2"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="202002281351"/>
+                                <high value="202002281351"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id nullFlavor="NA"/>
+                                    <code code="409586006" displayName="Complaint"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20200228"/>
+                                    <value nullFlavor="UNK" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#Encounter_2"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </entryRelationship>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="5ad6f921-233e-4d8c-927d-ecfd26bfbaf9"/>
+                                            <code code="282291009"
+                                                displayName="Diagnosis interpretation (observable entity)"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation code="29308-4" displayName="Diagnosis"
+                                                  codeSystem="2.16.840.1.113883.6.1"
+                                                  codeSystemName="LOINC"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20200228"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="I10" displayName="Hypertension"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20200228"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202002281406-0500"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                  <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                  <id root="1.174" extension="00001"/>
+                                                  <name>MU_Test</name>
+                                                  <telecom nullFlavor="UNK"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                    <entry>
+                        <encounter classCode="ENC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.49"
+                                extension="2015-08-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"/>
+                            <code nullFlavor="UNK">
+                                <originalText>
+                                    <reference value="#Encounter_3"/>
+                                </originalText>
+                            </code>
+                            <text>
+                                <reference value="#Encounter_3"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="201506221000"/>
+                                <high value="201506221000"/>
+                            </effectiveTime>
+                            <performer typeCode="PRF">
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id extension="0ede25f4-b431-44b0-8709-7212bcc995f3"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="tel:+1-5555551002"/>
+                                    <telecom use="MC" value="tel:+1-555551002"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <performer>
+                                <assignedEntity classCode="ASSIGNED">
+                                    <id nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine nullFlavor="UNK"/>
+                                        <city nullFlavor="UNK"/>
+                                        <state nullFlavor="UNK"/>
+                                        <postalCode nullFlavor="UNK"/>
+                                        <country nullFlavor="UNK"/>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name/>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedEntity>
+                            </performer>
+                            <participant typeCode="LOC">
+                                <participantRole classCode="SDLOC">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.32"/>
+                                    <id extension="c720f215-ad19-42d4-b01b-ee61e0ca0670"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" nullFlavor="UNK"/>
+                                    <playingEntity classCode="PLC">
+                                        <name>Neighborhood Physicians Practice</name>
+                                    </playingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.80"
+                                        extension="2015-08-01"/>
+                                    <code code="29308-4" displayName="Diagnosis"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                                        xsi:type="CE"/>
+                                    <entryRelationship typeCode="SUBJ">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.4"
+                                                extension="2015-08-01"/>
+                                            <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                            <code code="~" displayName="~"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT">
+                                                <translation nullFlavor="NA"/>
+                                            </code>
+                                            <statusCode code="completed"/>
+                                            <effectiveTime>
+                                                <low value="20150622"/>
+                                                <high nullFlavor="UNK"/>
+                                            </effectiveTime>
+                                            <value code="R50.9" displayName="Fever - Finding"
+                                                codeSystem="2.16.840.1.113883.6.90"
+                                                codeSystemName="ICD-10" xsi:type="CD"/>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                                <time value="20150622"/>
+                                                <assignedAuthor>
+                                                  <id root="1.174"
+                                                  extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <streetAddressLine>C/O Tracy
+                                                  Davis</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom use="WP" value="tel:+1-5555551002"/>
+                                                  <addr>
+                                                  <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                  <city>Beaverton</city>
+                                                  <state>OR</state>
+                                                  <postalCode>97006</postalCode>
+                                                  <country>US</country>
+                                                  </addr>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                            <author>
+                                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                                  extension="2019-10-01"/>
+                                                <time value="202103261221-0400"/>
+                                                <assignedAuthor>
+                                                  <id nullFlavor="UNK"/>
+                                                  <assignedPerson>
+                                                  <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                  </name>
+                                                  </assignedPerson>
+                                                  <representedOrganization>
+                                                  <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                  <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                  <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                  <name>Neighborhood Physicians Practice</name>
+                                                  <telecom value="5555551002"/>
+                                                  </representedOrganization>
+                                                </assignedAuthor>
+                                            </author>
+                                        </observation>
+                                    </entryRelationship>
+                                </act>
+                            </entryRelationship>
+                        </encounter>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.15" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FamilyHistory"/>
+                    <code code="10157-6" displayName="HISTORY OF FAMILY MEMBER DISEASES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Family History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Family Member</th>
+                                    <th>Type</th>
+                                    <th>Diagnosis</th>
+                                    <th>Age At Onset</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_0"
+                                            xmlns="urn:hl7-org:v3">Alive and well</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Brother</content>
+                                    </td>
+                                    <td>
+                                        <content>Problem (finding)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FamilyHistoryDiagnosis_1"
+                                            xmlns="urn:hl7-org:v3">Family history of
+                                            asthma</content>
+                                    </td>
+                                    <td>
+                                        <content>16</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.45"
+                                extension="2015-08-01"/>
+                            <id nullFlavor="NA"/>
+                            <statusCode code="completed"/>
+                            <subject>
+                                <relatedSubject classCode="PRS">
+                                    <code code="BRO" displayName="Brother"
+                                        codeSystem="2.16.840.1.113883.5.111"
+                                        codeSystemName="HL7RoleCode"/>
+                                    <subject>
+                                        <sdtc:id root="1.3.6.1.4.1.21367.13.40.117"
+                                            extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"
+                                            xmlns:sdtc="urn:hl7-org:sdtc"/>
+                                        <name>Kenneth</name>
+                                        <administrativeGenderCode code="M" displayName="Male"
+                                            codeSystem="2.16.840.1.113883.5.1"
+                                            codeSystemName="HL7AdministrativeGender"/>
+                                        <birthTime nullFlavor="UNK"/>
+                                    </subject>
+                                </relatedSubject>
+                            </subject>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="ab2bcf14-2c8b-43fc-9103-c86a95c0310d"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160445003" displayName="Alive and well"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_0"/>
+                                        </originalText>
+                                    </value>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.46"
+                                        extension="2015-08-01"/>
+                                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                                        extension="d1af37b2-178e-4cd9-ae47-3f63d9d6947f"/>
+                                    <code code="55607006" displayName="Problem (finding)"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT">
+                                        <translation code="75318-6"
+                                            displayName="Problem Family member"
+                                            codeSystem="2.16.840.1.113883.6.1"
+                                            codeSystemName="LOINC"/>
+                                    </code>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20171101">
+                                        <low value="20171101"/>
+                                    </effectiveTime>
+                                    <value code="160377001" displayName="Family history of asthma"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD">
+                                        <originalText>
+                                            <reference value="#FamilyHistoryDiagnosis_1"/>
+                                        </originalText>
+                                    </value>
+                                    <entryRelationship typeCode="SUBJ" inversionInd="true">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.31"/>
+                                            <code code="445518008" displayName="Age At Onset"
+                                                codeSystem="2.16.840.1.113883.6.96"
+                                                codeSystemName="SNOMED CT"/>
+                                            <statusCode code="completed"/>
+                                            <value value="16" unit="a" xsi:type="PQ"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Immunizations"/>
+                    <code code="11369-6" displayName="HISTORY OF IMMUNIZATION NARRATIVE"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Immunizations</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Vaccine</th>
+                                    <th>Date</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_0" xmlns="urn:hl7-org:v3"
+                                            >influenza, intradermal, quadrivalent, preservative
+                                            free, injectable</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>refused</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_0" xmlns="urn:hl7-org:v3"
+                                            >Note: Immunization was not given - Patient rejected
+                                            immunization. ; Source: New Immunization Record
+                                        </content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Immunization_1" xmlns="urn:hl7-org:v3"
+                                            >diphtheria, tetanus toxoids and acellular pertussis
+                                            vaccine, 5 pertussis antigens</content>
+                                    </td>
+                                    <td>
+                                        <content>Jan-04-2012</content>
+                                    </td>
+                                    <td>
+                                        <content>administered</content>
+                                    </td>
+                                    <td>
+                                        <content ID="ImmunizationComments_1" xmlns="urn:hl7-org:v3"
+                                            >Source: Source Unspecified </content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN" negationInd="true">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="51f02998-93bb-4385-9050-873373b9fc44"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_0"/>
+                            </text>
+                            <statusCode code="aborted"/>
+                            <effectiveTime value="20150622"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="166"
+                                            displayName="influenza, intradermal, quadrivalent, preservative free, injectable"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_0"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText nullFlavor="UNK"/>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319185347"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706151004-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <substanceAdministration classCode="SBADM" moodCode="EVN"
+                            negationInd="false">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.52"
+                                extension="2015-08-01"/>
+                            <id root="ba7049e4-8bcb-4a44-84e8-9e3f40d28f5f"/>
+                            <code code="IMMUNIZ" codeSystem="2.16.840.1.113883.5.4"
+                                codeSystemName="ActCode"/>
+                            <text>
+                                <reference value="#Immunization_1"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20120104"/>
+                            <doseQuantity nullFlavor="UNK"/>
+                            <consumable typeCode="CSM">
+                                <manufacturedProduct classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.54"
+                                        extension="2014-06-09"/>
+                                    <manufacturedMaterial>
+                                        <code code="106"
+                                            displayName="diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+                                            codeSystem="2.16.840.1.113883.12.292"
+                                            codeSystemName="CVX">
+                                            <originalText>
+                                                <reference value="#Immunization_1"/>
+                                            </originalText>
+                                        </code>
+                                        <lotNumberText>2</lotNumberText>
+                                    </manufacturedMaterial>
+                                    <manufacturerOrganization classCode="ORG">
+                                        <name>Immuno-U.S., Inc.</name>
+                                    </manufacturerOrganization>
+                                </manufacturedProduct>
+                            </consumable>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20170319184655"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="3ed2248d-71df-44d7-b075-0de276677506"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Murphy</family>
+                                            <given>Meghan</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201705081257-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="SUBJ">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.64"/>
+                                    <code code="48767-8" displayName="ANNOTATION COMMENT"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#ImmunizationComments_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                            <entryRelationship typeCode="RSON">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                        extension="2014-06-09"/>
+                                    <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                </observation>
+                            </entryRelationship>
+                        </substanceAdministration>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.18" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Payer"/>
+                    <code code="48768-6" displayName="PAYMENT SOURCES"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Payers</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Payer name</th>
+                                    <th>Insurance type</th>
+                                    <th>Covered party ID</th>
+                                    <th>Authorization(s)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="4">
+                                        <content ID="UnknownPayer" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.17" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="SocialHistory"/>
+                    <code code="29762-2" displayName="SOCIAL HISTORY"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Social History</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Description</th>
+                                    <th>Quantity</th>
+                                    <th>Date Captured</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_0" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_0"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_0"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_1" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_1"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_1"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_2" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Cigarette smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_2"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_3" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>Current every day smoker</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_3"
+                                            xmlns="urn:hl7-org:v3">Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobacco_5"
+                                            xmlns="urn:hl7-org:v3">Smoking Tobacco Use
+                                            Details</content>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <paragraph xmlns="urn:hl7-org:v3">Cigarette: No Details
+                                            Available<br/></paragraph>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingTobaccoDate_5"
+                                            xmlns="urn:hl7-org:v3">Aug-17-2017</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_6" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_6"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_6"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_7" xmlns="urn:hl7-org:v3"
+                                            >Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_7"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_7"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_8" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_8"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_9" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_9"
+                                            xmlns="urn:hl7-org:v3">Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryAlcohol_11" xmlns="urn:hl7-org:v3"
+                                            >Alcohol Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholValue_11"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryAlcoholDate_11"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeine_12"
+                                            xmlns="urn:hl7-org:v3">Caffeine Use Details</content>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineValue_12"
+                                            xmlns="urn:hl7-org:v3">Unknown</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryCaffeineDate_12"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistoryTobacco_13" xmlns="urn:hl7-org:v3"
+                                            >Tobacco Use Status</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistoryTobaccoDate_13"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="SocialHistorySmoking_14" xmlns="urn:hl7-org:v3"
+                                            >Smoking Status</content>
+                                    </td>
+                                    <td>
+                                        <content>No Information</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="SocialHistorySmokingDate_14"
+                                            xmlns="urn:hl7-org:v3">Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Birth Sex</content>
+                                    </td>
+                                    <td>
+                                        <content ID="BSex_value0" xmlns="urn:hl7-org:v3"
+                                            >Female</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_3"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20150622"/>
+                            <value code="449868002" displayName="Current every day smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_9"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200304"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.78"
+                                extension="2014-06-09"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HistoryOfTobaccoUse"/>
+                            <code code="72166-2" displayName="Tobacco smoking status NHIS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistorySmoking_14"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20200228"/>
+                            <value code="266927001" displayName="Unknown if ever smoked"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_0"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_6"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="AlcoholIntake"/>
+                            <code code="160573003" displayName="Alcohol intake"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryAlcohol_11"/>
+                                </originalText>
+                                <translation code="74013-4" displayName="Alcohol drinks per day"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.85"
+                                extension="2014-06-09"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe" extension="TobaccoUse"/>
+                            <code code="11367-0" displayName="History of tobacco use"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#SocialHistoryTobacco_2"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value code="65568007" displayName="Cigarette smoker"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_1"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201801311357-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Canonica</family>
+                                            <given>Gina</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_7"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200304"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202003041440-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="26db8415-1153-455c-a328-da1aeb35e30f"
+                                extension="HealthRelatedBehavior"/>
+                            <code code="228272008" displayName="Health-related Behavior"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistoryCaffeine_12"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20200228"/>
+                            </effectiveTime>
+                            <value nullFlavor="UNK" xsi:type="ST"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281406-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.38"
+                                extension="2015-08-01"/>
+                            <id root="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                extension="SmokingTobacco"/>
+                            <code code="229819007" displayName="Tobacco use and exposure"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <originalText>
+                                    <reference value="#SocialHistorySmokingTobacco_5"/>
+                                </originalText>
+                                <translation code="29762-2" displayName="Social history Narrative"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20170817"/>
+                            </effectiveTime>
+                            <value xsi:type="ST">Cigarette: No Details Available Quantity Details -
+                                Cigarette: No Details Available </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708170737-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.200"
+                                extension="2016-06-01"/>
+                            <code code="76689-9" displayName="Sex Assigned At Birth"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#BSex_value0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="F" displayName="Female" codeSystem="2.16.840.1.113883.5.1"
+                                codeSystemName="HL7AdministrativeGender" xsi:type="CD">
+                                <originalText>
+                                    <reference value="#BSex_value0"/>
+                                </originalText>
+                            </value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202104020755-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="VitalSigns"/>
+                    <code code="8716-3" displayName="VITAL SIGNS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Vital Signs</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date / Time:</th>
+                                    <th>Height</th>
+                                    <th>Weight</th>
+                                    <th>BMI</th>
+                                    <th>Pulse Rate</th>
+                                    <th>Blood Pressure</th>
+                                    <th>Temperature</th>
+                                    <th>Respiratory Rate</th>
+                                    <th>Body Surface Area</th>
+                                    <th>Head Circumference</th>
+                                    <th>Head Circ. Percentile</th>
+                                    <th>Wt./Len. Percentile</th>
+                                    <th>BMI percentile</th>
+                                    <th>Pulse Ox</th>
+                                    <th>Inhaled Ox</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015 10:05 AM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_0" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_0" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_0" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeartBeat_0" xmlns="urn:hl7-org:v3"
+                                            >80 /min</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_0"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_0" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsRespiratoryRate_0"
+                                            xmlns="urn:hl7-org:v3">18 /min</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsPulseOx_0" xmlns="urn:hl7-org:v3">95
+                                            %</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsInhaledOxyConc_0"
+                                            xmlns="urn:hl7-org:v3">36 %</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020 1:55 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_1" xmlns="urn:hl7-org:v3"
+                                            >69.69 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_1" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (194.01 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_1" xmlns="urn:hl7-org:v3">28.08
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_1"
+                                            xmlns="urn:hl7-org:v3">150/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsTemperature_1" xmlns="urn:hl7-org:v3"
+                                            >100.40 F</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020 1:59 PM</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsHeight_2" xmlns="urn:hl7-org:v3"
+                                            >65.00 in</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsWeight_2" xmlns="urn:hl7-org:v3"
+                                            >88.000 kg (165.00 lbs)</content>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBmi_2" xmlns="urn:hl7-org:v3">27.46
+                                            kg/meter(2)</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content ID="VitalSignsBloodPressure_2"
+                                            xmlns="urn:hl7-org:v3">145/88 mm[Hg]</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="201506221005-0400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20150622"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201707271030-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_height_0"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_weight_0"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_systolic_0"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="intravascular_diastolic_0"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="heart_rate_0"/>
+                                    <code code="8867-4" displayName="Heart Rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeartBeat_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="80" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_temperature_0"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="respiratory_rate_0"/>
+                                    <code code="9279-1" displayName="Respiratory rate"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsRespiratoryRate_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="18" unit="/min"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="sao2_%_blda_pulseox_0"/>
+                                    <code code="59408-5" displayName="SaO2 % BldA PulseOx"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsPulseOx_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="95" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="inhaled_oxygen_concentration_0"/>
+                                    <code code="3150-0" displayName="Inhaled Oxygen Concentration"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsInhaledOxyConc_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="36" unit="%"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202003041355-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200304"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="a97bff45-d9ec-4e08-bd47-d5a0371f19a0"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111850-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_height_1"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_weight_1"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_systolic_1"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="150" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="intravascular_diastolic_1"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_temperature_1"/>
+                                    <code code="8310-5" displayName="Body Temperature"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsTemperature_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="38.00" unit="Cel"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="b770a326-687e-4b64-b13f-4b194ea8d5cd"
+                                        extension="body_mass_index_1"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_1"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202003041355-0500"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202101111850-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Admin</family>
+                                                  <given>NEXTGEN</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="d527d655-4e2c-4630-a964-7eb4b47d8a22"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99211"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry typeCode="DRIV">
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                                extension="2015-08-01"/>
+                            <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"/>
+                            <code code="46680005" displayName="Vital signs"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                                <translation code="74728-7"
+                                    displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="202002281359-0500"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20200228"/>
+                                <assignedAuthor>
+                                    <id root="1.174" extension="43"/>
+                                    <addr nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202002281401-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Bradshaw</family>
+                                            <given>Lisa</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_height_2"/>
+                                    <code code="8302-2" displayName="Body height"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsHeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="177.00" unit="cm"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_weight_2"/>
+                                    <code code="29463-7" displayName="Body Weight"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsWeight_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88.000" unit="kg"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_systolic_2"/>
+                                    <code code="8480-6" displayName="Intravascular Systolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="145" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="intravascular_diastolic_2"/>
+                                    <code code="8462-4" displayName="Intravascular Diastolic"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBloodPressure_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="88" unit="mm[Hg]"/>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="43bd9138-d6ac-46cb-8145-0c8c708b9a0c"
+                                        extension="body_mass_index_2"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_2"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="202002281359-0500"/>
+                                    <value xsi:type="PQ" value="27.46" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="202002281401-0500"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Bradshaw</family>
+                                                  <given>Lisa</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                                <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                                <id root="1.174" extension="00001"/>
+                                                <name>MU_Test</name>
+                                                <telecom nullFlavor="UNK"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="26db8415-1153-455c-a328-da1aeb35e30f"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code code="99212"
+                                                displayName="OFFICE/OUTPATIENT VISIT, EST"
+                                                codeSystem="2.16.840.1.113883.6.12"
+                                                codeSystemName="CPT4"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.13"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="ChiefComplaintAndReasonForVisit"/>
+                    <code code="46239-0" displayName="CHIEF COMPLAINT AND REASON FOR VISIT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Chief Complaint And Reason For Visit</title>
+                    <text>
+                        <paragraph>No Information</paragraph>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1"/>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.1" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ReferralReason"/>
+                    <code code="42349-1" displayName="REASON FOR REFERRAL"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Reason For Referral</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Reason For Referral</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="1">
+                                        <content ID="UnknownReferral" xmlns="urn:hl7-org:v3">No
+                                            Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.10" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="PlanOfCare"/>
+                    <code code="18776-5" displayName="TREATMENT PLAN"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Plan Of Treatment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Type</th>
+                                    <th>Action</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Radiology Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_0" xmlns="urn:hl7-org:v3">EKG
+                                            (93000), Scheduled for: Jun-23-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Future Order: Lab Order</content>
+                                    </td>
+                                    <td>
+                                        <content ID="FutureOrder_1" xmlns="urn:hl7-org:v3"
+                                            >Urinanalysis macro (dipstick) panel (81002), Scheduled
+                                            for: Jun-29-2015</content>
+                                    </td>
+                                    <td>
+                                        <content>Ordered</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="bdb795ab-6f6d-415e-956c-fb87940dd574"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#FutureOrder_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506230400"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201708151638-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation classCode="OBS" moodCode="RQO">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.44"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="3f143484-5a7b-4aca-acab-1bf2f8539896"/>
+                            <code code="24357-6"
+                                displayName="Urinalysis macro (dipstick) panel - Urine"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#FutureOrder_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="201506291200"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706201725-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HistoryOfPresentIllness"/>
+                    <code code="10164-2" displayName="HISTORY OF PRESENT ILLNESS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History Of Present Illness</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Encounter Date</th>
+                                    <th>Complaint</th>
+                                    <th>History Of Present Illness</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>Sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>sore throat</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                    <td>
+                                        <content>hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>The HTN started in 2015. The symptoms began
+                                            gradually. The severity has been described as being 6.
+                                            It is currently stable. Risk factors include inactive
+                                            lifestyle, obesity, sleep apnea and smoking. The
+                                            hypertension is exacerbated by anxiety. Associated
+                                            symptoms include fatigue and headache.</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.14" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="FunctionalStatus"/>
+                    <code code="47420-5" displayName="Functional Status"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Functional Status</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Functional Assessment</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>May-01-2005</content>
+                                    </td>
+                                    <td>
+                                        <content>Dependence on cane</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.66"
+                                extension="2014-06-09"/>
+                            <id nullFlavor="UNK"/>
+                            <code nullFlavor="NP"/>
+                            <statusCode code="completed"/>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.67"
+                                        extension="2014-06-09"/>
+                                    <id root="e942984a-f2fb-416e-80ce-d481c8b0fb71"/>
+                                    <code code="54522-8" displayName="Functional Status"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="20050501"/>
+                                    <value code="105504002" displayName="Dependence on cane"
+                                        codeSystem="2.16.840.1.113883.6.96"
+                                        codeSystemName="SNOMED CT" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                            <component>
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.128"/>
+                                    <id nullFlavor="UNK"/>
+                                    <code nullFlavor="UNK"/>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime nullFlavor="UNK"/>
+                                    <value nullFlavor="UNK" xsi:type="CD"/>
+                                </observation>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CcdaMedicationsAdministered"/>
+                    <code code="29549-3" displayName="MEDICATION ADMINISTERED"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medications Administered</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Medication</th>
+                                    <th>Instructions</th>
+                                    <th>Dosage</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Comments</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="6">
+                                        <content ID="UnknownMedicationAdministered"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.45" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Instructions"/>
+                    <code code="69730-0" displayName="INSTRUCTIONS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Instructions</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Date</th>
+                                    <th>Instruction</th>
+                                    <th>Additional Information</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                    <td>
+                                        <content ID="PatientInstruction_0" xmlns="urn:hl7-org:v3">i.
+                                            Get an EKG done on 6/23/2015. ii. Get a Chest X-ray done
+                                            on 6/23/2015 showing the Lower Respiratory Tract
+                                            Structure. iii. Take Clindamycin 300mg three times a day
+                                            as needed if pain does not subside. iv. Schedule follow
+                                            on visit with Neighborhood Physicians Practice on
+                                            7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Related to Fever - Finding</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act moodCode="INT" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.20"
+                                extension="2014-06-09"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="1d98f86c-5319-45d4-98fa-a26df91591dc"/>
+                            <code code="423564006" displayName="Provider Instructions for treatment"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"/>
+                            <text>
+                                <reference value="#PatientInstruction_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime>
+                                <low value="20150622110000"/>
+                            </effectiveTime>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.8"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Assessment"/>
+                    <code code="51848-0" displayName="ASSESSMENTS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Assessments</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Type</th>
+                                    <th>Assessment</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Fever - Finding</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>impression</content>
+                                    </td>
+                                    <td>
+                                        <content>The patient was found to have fever and Dr Davis is
+                                            suspecting Anemia based on the patient history. So Dr
+                                            Davis asked the patient to closely monitor the
+                                            temperature and blood pressure and get admitted to
+                                            Community Health Hospitals if the fever does not subside
+                                            within a day. i. Get an EKG done on 6/23/2015. ii. Take
+                                            Clindamycin 300mg three times a day as needed if pain
+                                            does not subside. iii. Schedule follow on visit with
+                                            Neighborhood Physicians Practice on 7/1/2015.</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Acute tonsillitis due to other specified
+                                            organisms</content>
+                                    </td>
+                                    <td>
+                                        <content>Mar-04-2020</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>assessment</content>
+                                    </td>
+                                    <td>
+                                        <content>Hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Feb-28-2020</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.60"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="Goals"/>
+                    <code code="61146-7" displayName="GOALS" codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"/>
+                    <title>Goals</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Health Concern</th>
+                                    <th>Goal</th>
+                                    <th>Type</th>
+                                    <th>Priority</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content>Fever</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_0" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occurring every few
+                                            weeks.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_1" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities.</content>
+                                    </td>
+                                    <td>
+                                        <content>Provider Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_2" xmlns="urn:hl7-org:v3">Get rid of
+                                            intermittent fever that is occuring every few
+                                            weeks</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content>Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content ID="CPGoal_3" xmlns="urn:hl7-org:v3">Need to gain
+                                            more energy to do regular activities</content>
+                                    </td>
+                                    <td>
+                                        <content>Patient Goal</content>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                    <td>
+                                        <content/>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="3b72c7a7-2b83-4e68-a1c9-bcc637fd389f"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occurring
+                                every few weeks.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="d2b8277e-2016-4489-b2db-34360fde0cd0"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities.</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061640-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="eff3999e-ad61-477c-864f-402b281924a3"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Get rid of intermittent fever that is occuring
+                                every few weeks</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <observation moodCode="GOL" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.121"/>
+                            <id root="41ccf5d4-05af-48f1-949d-659040b8a781"/>
+                            <code nullFlavor="UNK"/>
+                            <text>
+                                <reference value="#CPGoal_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <value xsi:type="ST">Need to gain more energy to do regular
+                                activities</value>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id root="1.100" extension="8658"/>
+                                    <addr>
+                                        <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <telecom use="WP" value="mailto:sadavis@nextgen.com"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Newman</family>
+                                            <given>Alice</given>
+                                            <given>Jones</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111913-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </observation>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23"/>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.23" extension="2014-06-09"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="MedicalEquipment"/>
+                    <code code="46264-8" displayName="MEDICAL EQUIPMENT"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Medical Equipment</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Description</th>
+                                    <th>Device</th>
+                                    <th>Universal Device Identifier</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Device Status</th>
+                                    <th>Implantable Device Status</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="ImplantableProcDev__0_0" xmlns="urn:hl7-org:v3"
+                                            >CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>CRT-D DTBA1QQ VIVA QUAD XT US IS4/DF4</content>
+                                    </td>
+                                    <td>
+                                        <content>(01)00643169007222(17)160128(21)BLC200461H</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <procedure classCode="PROC" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.313"
+                                extension="2018-05-01"/>
+                            <id root="1.3.6.1.4.1.21367.13.40.117"
+                                extension="f2a75542-ea11-480d-8baf-dd381668c328"/>
+                            <code code="33216"
+                                displayName="Introduction of cardiac pacemaker system via vein"
+                                codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT4"
+                                xsi:type="CE"/>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time value="20111005"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706050158-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <participant typeCode="DEV">
+                                <participantRole classCode="MANU">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.310"
+                                        extension="2018-05-01"/>
+                                    <id root="2.16.840.1.113883.3.3719"
+                                        extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        assigningAuthorityName="FDA"/>
+                                    <playingDevice>
+                                        <code nullFlavor="UNK">
+                                            <originalText>
+                                                <reference value="#ImplantableProcDev__0_0"/>
+                                            </originalText>
+                                        </code>
+                                    </playingDevice>
+                                    <scopingEntity>
+                                        <id root="2.16.840.1.113883.3.3719"/>
+                                    </scopingEntity>
+                                </participantRole>
+                            </participant>
+                            <entryRelationship typeCode="COMP">
+                                <organizer classCode="CLUSTER" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.311"
+                                        extension="2019-06-21"/>
+                                    <id extension="(01)00643169007222(17)160128(21)BLC200461H"
+                                        root="2.16.840.1.113883.3.3719"/>
+                                    <code code="74711-3" displayName="Unique Device Identifier"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="completed"/>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.304"
+                                                extension="2019-06-21"/>
+                                            <code code="C101722" displayName="Primary DI Number"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value root="1.3.160" extension="00643169007222"
+                                                displayable="true" assigningAuthorityName="GS1"
+                                                xsi:type="II"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.318"
+                                                extension="2019-06-21"/>
+                                            <code code="C106044" displayName="MRI Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C113844"
+                                                displayName="Labeling does not contain MRI Safety Information"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.46"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.314"
+                                                extension="2019-06-21"/>
+                                            <code code="C160938" displayName="Latex Safety Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C106038"
+                                                displayName="Not Made with Natural Rubber Latex"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.47"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.305"
+                                                extension="2019-06-21"/>
+                                            <code code="C160939"
+                                                displayName="Implantable Device Status"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus"/>
+                                            <value code="C45329" displayName="Active"
+                                                codeSystem="2.16.840.1.113883.3.26.1.1"
+                                                codeSystemName="NCI Thesaurus" xsi:type="CD"
+                                                sdtc:valueSet="2.16.840.1.113762.1.4.1021.48"/>
+                                        </observation>
+                                    </component>
+                                    <component>
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.306"
+                                                extension="2018-05-01"/>
+                                            <code code="UDI-00007" displayName="Device Status"
+                                                codeSystem="1.3.6.1.4.1.19376.1.4.1.6.5.290"
+                                                codeSystemName="UDI Observation Type"/>
+                                            <value code="active"
+                                                codeSystem="2.16.840.1.113883.4.642.3.199"
+                                                codeSystemName="Device Status" xsi:type="CD"/>
+                                        </observation>
+                                    </component>
+                                </organizer>
+                            </entryRelationship>
+                        </procedure>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.58" extension="2015-08-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="HealthConcerns"/>
+                    <code code="75310-3" displayName="HEALTH CONCERNS"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Health Concerns</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Observation</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthStatusObs_0" xmlns="urn:hl7-org:v3"
+                                            >Chronically ill</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Concern</th>
+                                    <th>Status</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_0" xmlns="urn:hl7-org:v3"
+                                            >Chronic Sickness exhibited by patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_1" xmlns="urn:hl7-org:v3"
+                                            >Weight - 88.000 kg</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_2" xmlns="urn:hl7-org:v3"
+                                            >Fever - Finding - R50.9</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_3" xmlns="urn:hl7-org:v3">BMI
+                                            - 28.08 - Watch weight of patient</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_4" xmlns="urn:hl7-org:v3"
+                                            >Fever</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_5" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_6" xmlns="urn:hl7-org:v3"
+                                            >Essential hypertension</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Oct-05-2011</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_7" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="HealthConcernAct_8" xmlns="urn:hl7-org:v3"
+                                            >Severe hypothyroidism</content>
+                                    </td>
+                                    <td>
+                                        <content>Active</content>
+                                    </td>
+                                    <td>
+                                        <content>Dec-31-2006</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <observation moodCode="EVN" classCode="OBS">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5"/>
+                            <templateId root="2.16.840.1.113883.10.20.22.4.5" extension="2014-06-09"/>
+                            <id root="45cf87bf-0952-4e7c-b049-ad19b435729e"/>
+                            <code code="11323-3" displayName="HEALTH STATUS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthStatusObs_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <value code="161901003" displayName="Chronically ill"
+                                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT"
+                                xsi:type="CD"/>
+                        </observation>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="4484e3ed-2abe-4330-8e28-2914807dd8d1"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_0"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111912-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c7dcddd1-8a45-4536-8975-9df72a77d474"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_1"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6c1d5761-3b89-4592-97ac-67905ef3e3d8"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_2"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111910-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="21a44e58-e0d5-42a0-bbda-366842d476a7"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="a30988e2-aab4-4ff7-8ac8-a286393f22fb"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_3"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061059-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <observation classCode="OBS" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"/>
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                                        extension="2014-06-09"/>
+                                    <id root="aee5c0d6-b4d3-47e6-99f5-da4d5aaf8a48"
+                                        extension="body_mass_index_0"/>
+                                    <code code="39156-5" displayName="Body mass index"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <text>
+                                        <reference value="#VitalSignsBmi_0"/>
+                                    </text>
+                                    <statusCode code="completed"/>
+                                    <effectiveTime value="201506221005-0400"/>
+                                    <value xsi:type="PQ" value="28.08" unit="kg/m2"/>
+                                    <interpretationCode nullFlavor="OTH"
+                                        codeSystem="2.16.840.1.113883.5.83">
+                                        <translation code="238131007"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            displayName="Overweight" codeSystemName="SNOMED CT"/>
+                                    </interpretationCode>
+                                    <author>
+                                        <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                            extension="2019-10-01"/>
+                                        <time value="201707271030-0400"/>
+                                        <assignedAuthor>
+                                            <id nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                            <representedOrganization>
+                                                <id root="2.16.840.1.113883.4.2"
+                                                  extension="456745672"/>
+                                                <id root="2.16.840.1.113883.4.6"
+                                                  extension="1093929010"/>
+                                                <id root="1.3.6.1.4.1.21367.13.40.117"
+                                                  extension="0001"/>
+                                                <name>Neighborhood Physicians Practice</name>
+                                                <telecom value="5555551002"/>
+                                            </representedOrganization>
+                                        </assignedAuthor>
+                                    </author>
+                                    <entryRelationship typeCode="RSON">
+                                        <observation classCode="OBS" moodCode="EVN">
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"/>
+                                            <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                                                extension="2014-06-09"/>
+                                            <id extension="50f415aa-88a4-4d49-91f4-4ce2d597fbbe"
+                                                root="1.3.6.1.4.1.21367.13.40.117"/>
+                                            <code nullFlavor="UNK"/>
+                                            <statusCode code="completed"/>
+                                        </observation>
+                                    </entryRelationship>
+                                </observation>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="6b066929-4f5e-4cd1-b7b9-ed13c9af51e4"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_4"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20150622"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061100-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="5214ea51-a323-4a9e-860d-7b8f688688cd"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_5"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="deda0b49-2996-411b-b9b9-e517db9bec04"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_6"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20111005"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061057-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="83e22d2f-ffdc-414b-a075-88ad6d0dbfc3"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="c5bb9c90-1562-42b4-a2c1-fcf7868443e5"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_7"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101111911-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Admin</family>
+                                            <given>NEXTGEN</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                    <entry>
+                        <act moodCode="EVN" classCode="ACT">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.132"
+                                extension="2015-08-01"/>
+                            <id root="3dc0283f-022a-44be-abbf-9269a0b10b4f"/>
+                            <code code="75310-3" displayName="HEALTH CONCERNS"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            <text>
+                                <reference value="#HealthConcernAct_8"/>
+                            </text>
+                            <statusCode code="active"/>
+                            <effectiveTime value="20061231"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="201706061058-0400"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>User</family>
+                                            <given>Adam</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <id root="2.16.840.1.113883.4.6" nullFlavor="UNK"/>
+                                        <id root="1.174" extension="00001"/>
+                                        <name>MU_Test</name>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="REFR">
+                                <act classCode="ACT" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.122"/>
+                                    <id root="09b0463a-9599-4004-b1c5-f2a9bb31b483"/>
+                                    <code nullFlavor="NP"/>
+                                    <statusCode code="completed"/>
+                                </act>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.500" extension="2019-07-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="CareTeam"/>
+                    <code code="85847-2" displayName="PATIENT CARE TEAM"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Patient Care Teams</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Effective Dates (start - stop)</th>
+                                    <th>Status</th>
+                                    <th>Members</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_0" xmlns="urn:hl7-org:v3">Core
+                                            Team</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>nullified</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item> Kristin Allison.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <content ID="Careteam_1" xmlns="urn:hl7-org:v3">Care Team
+                                            A</content>
+                                    </td>
+                                    <td>
+                                        <content>Jun-22-2015 - </content>
+                                    </td>
+                                    <td>
+                                        <content>active</content>
+                                    </td>
+                                    <td>
+                                        <list xmlns="urn:hl7-org:v3">
+                                            <item>[Family medicine specialist] Albert Davis, 2472
+                                                Rocky Place, Beaverton, OR, 97006.</item>
+                                            <item>[grandfather] Rick Holler, 1357 Amber Dr,
+                                                Beaverton, OR, 97006.</item>
+                                            <item>[spouse] Matthew Newman, 1357 Amber Dr.,
+                                                Beaverton, OR, 97006.</item>
+                                            <item> Tracy Davis, 2472 Rocky Place, Beaverton, OR,
+                                                97006.</item>
+                                        </list>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="5ae3655e-dfe0-4bf9-9ec3-b3693d6956f5"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_0"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="nullified"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101291121-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="9a7b1756-d0a6-4db9-93f9-260dbaa04dc7"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode nullFlavor="UNK"/>
+                                    <effectiveTime>
+                                        <low nullFlavor="UNK"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low nullFlavor="UNK"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id root="2.16.840.1.113883.4.6" extension="1528951720"/>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Allison</family>
+                                                  <given>Kristin</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr nullFlavor="UNK"/>
+                                            <telecom nullFlavor="UNK"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                    <entry>
+                        <organizer classCode="CLUSTER" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.500"
+                                extension="2019-07-01"/>
+                            <id root="1755af9d-4c9f-4442-ac10-fc9d2b264338"/>
+                            <code code="86744-0" displayName="Care Team"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <originalText>
+                                    <reference value="#Careteam_1"/>
+                                </originalText>
+                            </code>
+                            <statusCode code="active"/>
+                            <effectiveTime>
+                                <low value="20150622"/>
+                                <high nullFlavor="UNK"/>
+                            </effectiveTime>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time value="202101191649-0500"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="6ebb65ef-0d6f-4358-87da-96e4b71f8b4b"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="207Q00000X"
+                                                displayName="Allopathic &amp; Osteopathic Physicians : Family Medicine"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Albert</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <sdtc:functionCode code="62247001"
+                                            displayName="Family medicine specialist"
+                                            codeSystem="2.16.840.1.113883.6.96"
+                                            codeSystemName="SNOMED CT"/>
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Neighborhood Physicians Practice</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="48563921-dded-4fc5-b54e-0b86775d7fca"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Holler</family>
+                                                  <given>Rick</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber Dr</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="335b6602-a8b2-4d3d-8744-9ad850e7ebc6"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Newman</family>
+                                                  <given>Matthew</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>1357 Amber
+                                                  Dr.</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country nullFlavor="UNK"/>
+                                            </addr>
+                                            <telecom use="HP" value="tel:+1-5557231544"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                            <component>
+                                <act classCode="PCPR" moodCode="EVN">
+                                    <templateId root="2.16.840.1.113883.10.20.22.4.500.1"
+                                        extension="2019-07-01"/>
+                                    <id root="b72378a1-6e51-4e33-a209-93374a095f12"/>
+                                    <code code="85847-2" displayName="Care Team Information"
+                                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                                    <statusCode code="active"/>
+                                    <effectiveTime>
+                                        <low value="20150622"/>
+                                        <high nullFlavor="UNK"/>
+                                    </effectiveTime>
+                                    <performer>
+                                        <time>
+                                            <low value="20150622"/>
+                                            <high nullFlavor="UNK"/>
+                                        </time>
+                                        <assignedEntity>
+                                            <id nullFlavor="UNK"/>
+                                            <code code="251B00000X"
+                                                displayName="Agencies : Case Management"
+                                                codeSystem="2.16.840.1.113883.6.101"
+                                                codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <assignedPerson>
+                                                <name>
+                                                  <family>Davis</family>
+                                                  <given>Tracy</given>
+                                                </name>
+                                            </assignedPerson>
+                                        </assignedEntity>
+                                    </performer>
+                                    <participant typeCode="IND">
+                                        <participantRole nullFlavor="NI"/>
+                                    </participant>
+                                    <participant typeCode="LOC">
+                                        <participantRole>
+                                            <addr>
+                                                <streetAddressLine>2472 Rocky
+                                                  Place</streetAddressLine>
+                                                <city>Beaverton</city>
+                                                <state>OR</state>
+                                                <postalCode>97006</postalCode>
+                                                <country>US</country>
+                                            </addr>
+                                            <telecom use="MC" value="tel:+1-5555551002"/>
+                                            <playingEntity>
+                                                <name>Unknown</name>
+                                            </playingEntity>
+                                        </participantRole>
+                                    </participant>
+                                </act>
+                            </component>
+                        </organizer>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="DischargeSummaryClinicalNotes"/>
+                    <code code="18842-5" displayName="Discharge summary"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Discharge Summary Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownDischargeSummaryClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="18842-5" displayName="Discharge summary"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownDischargeSummaryClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ConsultNoteClinicalNotes"/>
+                    <code code="11488-4" displayName="Consult Note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Consultation Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownConsultNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11488-4" displayName="Consult Note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownConsultNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section nullFlavor="NI">
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117"
+                        extension="HistoryPhysicalNoteClinicalNotes"/>
+                    <code code="34117-2" displayName="History and physical note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>History and Physical Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="2">
+                                        <content ID="UnknownHistoryPhysicalNoteClinicalNotes"
+                                            xmlns="urn:hl7-org:v3">No Information</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="34117-2" displayName="History and physical note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#UnknownHistoryPhysicalNoteClinicalNotes"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime nullFlavor="UNK"/>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <time nullFlavor="UNK"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <representedOrganization nullFlavor="NA">
+                                        <id root="2.16.840.1.113883.4.2" nullFlavor="UNK"/>
+                                        <name nullFlavor="UNK"/>
+                                        <telecom nullFlavor="UNK"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+            <component>
+                <section>
+                    <templateId root="2.16.840.1.113883.10.20.22.2.65" extension="2016-11-01"/>
+                    <id root="1.3.6.1.4.1.21367.13.40.117" extension="ProgressNoteNoteClinicalNotes"/>
+                    <code code="11506-3" displayName="Progress note"
+                        codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                    <title>Progress Notes</title>
+                    <text>
+                        <table border="1" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Clinical Note</th>
+                                    <th>Date</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <content ID="clinNotes_ProgressNoteNoteClinicalNotes_0"
+                                            xmlns="urn:hl7-org:v3">Ms Alice Newman seems to be
+                                            developing high fever and hence we recommend her to get
+                                            admitted to a nearby hospital using the provided
+                                            referral. </content>
+                                    </td>
+                                    <td>
+                                        <content>Sep-20-2021</content>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </text>
+                    <entry>
+                        <act classCode="ACT" moodCode="EVN">
+                        	<!--  Note Activity -->
+                            <templateId root="2.16.840.1.113883.10.20.22.4.202"
+                                extension="2016-11-01"/>
+                            <code code="34109-9" displayName="Note"
+                                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC">
+                                <translation code="11506-3" displayName="Progress note"
+                                    codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                            </code>
+                            <text>
+                                <reference value="#clinNotes_ProgressNoteNoteClinicalNotes_0"/>
+                            </text>
+                            <statusCode code="completed"/>
+                            <effectiveTime value="20210920"/>
+                            <author>
+                                <!-- Author Participation -->
+                                <templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+                                <!-- dbTest 2 
+                                 valid TS as per provenance reqs, but is not provenance, so irrelevant, no error expected
+                                 -->
+                                <time value="202109201442-0400"/>
+                                <assignedAuthor>
+                                    <id root="1.174"
+                                        extension="0ede25f4-b431-44b0-8709-7212bcc995f3"/>
+                                    <addr>
+                                        <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                        <streetAddressLine>C/O Tracy Davis</streetAddressLine>
+                                        <city>Beaverton</city>
+                                        <state>OR</state>
+                                        <postalCode>97006</postalCode>
+                                        <country>US</country>
+                                    </addr>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom use="WP" value="tel:+1-5555551002"/>
+                                        <addr>
+                                            <streetAddressLine>2472 Rocky Place</streetAddressLine>
+                                            <city>Beaverton</city>
+                                            <state>OR</state>
+                                            <postalCode>97006</postalCode>
+                                            <country>US</country>
+                                        </addr>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <author>
+                                <!--  Provenance -->
+                                <templateId root="2.16.840.1.113883.10.20.22.5.6"
+                                    extension="2019-10-01"/>
+                                <!-- Invalid time and should produce error (no time-zone) -->
+                                <time value="20210920144244"/>
+                                <assignedAuthor>
+                                    <id nullFlavor="UNK"/>
+                                    <assignedPerson>
+                                        <name>
+                                            <family>Davis</family>
+                                            <given>Albert</given>
+                                        </name>
+                                    </assignedPerson>
+                                    <representedOrganization>
+                                        <id root="2.16.840.1.113883.4.2" extension="456745672"/>
+                                        <id root="2.16.840.1.113883.4.6" extension="1093929010"/>
+                                        <id root="1.3.6.1.4.1.21367.13.40.117" extension="0001"/>
+                                        <name>Neighborhood Physicians Practice</name>
+                                        <telecom value="5555551002"/>
+                                    </representedOrganization>
+                                </assignedAuthor>
+                            </author>
+                            <entryRelationship typeCode="COMP" inversionInd="true">
+                                <encounter classCode="ENC" moodCode="EVN">
+                                    <id extension="9d7d931c-948f-4a59-a532-d9b96c868129"
+                                        root="1.3.6.1.4.1.21367.13.40.117"/>
+                                </encounter>
+                            </entryRelationship>
+                        </act>
+                    </entry>
+                </section>
+            </component>
+        </structuredBody>
+    </component>
+</ClinicalDocument>

--- a/src/test/resources/cures/sub/SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3252_b1TocAmbS3.xml
+++ b/src/test/resources/cures/sub/SubHasNotesSecNoteActAuthorTimeTimezone0400_SITE-3252_b1TocAmbS3.xml
@@ -2126,8 +2126,8 @@
                         <statusCode code="completed"/>
                         <effectiveTime value="20200622"></effectiveTime>
                         <author>
-                        	<!-- Author Participation -->
-                            <templateId root="2.16.840.1.113883.10.20.22.4.119" />
+							<!-- Provenance = 5.6 -->
+                            <templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
 							<time value="198506221100-05AB" />
 							<assignedAuthor>
    								<id extension="111111" root="2.16.840.1.113883.4.6"/>

--- a/src/test/resources/cures/sub/hasMixedDateAndTimeForAuthorTimeInDocLevAndVitalSignsSite3241.xml
+++ b/src/test/resources/cures/sub/hasMixedDateAndTimeForAuthorTimeInDocLevAndVitalSignsSite3241.xml
@@ -1882,7 +1882,9 @@
 									<value xsi:type="PQ" value="177" unit="cm"/>
 									<interpretationCode code="N" codeSystem="2.16.840.1.113883.5.83"/>
 									<author typeCode="AUT">
-										<templateId root="2.16.840.1.113883.10.20.22.4.119"/>
+										<!-- <templateId root="2.16.840.1.113883.10.20.22.4.119"/> -->
+										<!-- change to provenance vs prior author participation template -->
+										<templateId root="2.16.840.1.113883.10.20.22.5.6" extension="2019-10-01"/>
 										<!-- -dbTest 1 -->
 										<time value="201506221100-"/>
 										<!--<time value="201506221100-9999"/>-->


### PR DESCRIPTION
-Fixes mistaken identity issues when running sub-only validation on time
against anything other than Provenenace. In these cases, only provenance
will fail now (<templateId root="2.16.840.1.113883.10.20.22.5.6"
extension="2019-10-01"/>), vs, for example, (original) author
participation.
-SITE-3331 ETT GG, ContentVal: "Validator provenance timestamp errors
when multiple author nodes present"